### PR TITLE
Fix:account Level amount calc and tx deduplication

### DIFF
--- a/tests/spend_test.rs
+++ b/tests/spend_test.rs
@@ -83,7 +83,7 @@ mod spend_tests {
             .get_max_bump_fee(vec![], unconfirmed_tx.clone())
             .expect("Failed to get max bump fee");
 
-        assert_eq!(rbf_max_result.max_fee_rate, 658);
+        assert_eq!(rbf_max_result.max_fee_rate, 145);
         assert!(unconfirmed_tx.fee_rate < rbf_max_result.min_fee_rate);
         //
     }


### PR DESCRIPTION
If the user performs a self-spend between wallets within the same account, the account will have duplicate transactions one marked as "receive" and the other as "spend."

To compute the total sent and received amounts for a transaction, we need to sum the sent and received values across all wallets in the account.

This PR introduces a new account-level method sent_and_received to calculate the total amount of a transaction.
The method returns a `tuple (sent, received)`, where:

- `sent` is the sum of the txin amounts that spend from previous txouts tracked by the wallets in the account.

- `received` is the sum of the transaction’s outputs sent to script pubkeys tracked by the wallets in the account.

also improved first_seen handling for mempool transactions