### PR TITLE
fix: use proper address comparison in transform_psbt_to_bitcointx

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -465,7 +465,12 @@ impl<P: WalletPersister> NgAccount<P> {
 
         let mut amount = 0;
         for outputs in outputs.clone() {
-            if outputs.address == address {
+            let spend_address = Address::from_str(&address)
+                .expect("Unable to parse address in transform_psbt_to_bitcointx");
+            let output_address = Address::from_str(&outputs.address)
+                .expect("Unable to parse output_address in transform_psbt_to_bitcointx");
+            println!("spend_address: {spend_address:?}, output_address: {output_address:?}");
+            if spend_address.eq(&output_address) {
                 amount = -(outputs.amount as i64);
             }
         }

--- a/tests/spend_test.rs
+++ b/tests/spend_test.rs
@@ -4,6 +4,8 @@ mod utils;
 #[cfg(feature = "envoy")]
 mod spend_tests {
     use crate::utils::tests_util;
+    use bdk_wallet::rusqlite::Connection;
+    use ngwallet::account::NgAccount;
     use ngwallet::send::{DraftTransaction, TransactionParams};
 
     use crate::utils::tests_util::get_ng_hot_wallet;
@@ -68,7 +70,57 @@ mod spend_tests {
         assert_eq!(initial_indexes, post_compose_indexes);
     }
 
-    //
+    #[test]
+    fn test_address_formats() {
+        let mut account = get_ng_hot_wallet();
+        tests_util::add_funds_to_wallet(&mut account);
+
+        let test_addresses = vec![
+            "TB1QG6EPY90XX0HVHEGETCX7T8PMWA5YDP4SEEAN6Q", // uppercase bech32
+            "tb1qg6epy90xx0hvhegetcx7t8pmwa5ydp4seean6q", // lowercase bech32
+            "mxq7YK9GRJ5HjB9JqTThpAaJqwZ5D6KYtP",         // legacy P2PKH
+            "tb1pspfcrvz538vvj9f9gfkd85nu5ty98zw9y5e302kha6zurv6vg07s8z7a8w", // taproot
+            "2N3pSqDGfk16FrS91bXZi63Ns4VoeWnzQQf",        // p2sh
+        ];
+
+        for address in test_addresses {
+            test_address_compose(&mut account, address);
+        }
+    }
+
+    fn test_address_compose(account: &mut NgAccount<Connection>, address: &str) {
+        let initial_indexes = account.get_derivation_index();
+        let params = TransactionParams {
+            address: address.to_string(),
+            amount: 1000,
+            fee_rate: 2,
+            selected_outputs: vec![],
+            note: Some("not a note".to_string()),
+            tag: Some("hello".to_string()),
+            do_not_spend_change: false,
+        };
+
+        let draft = account.compose_psbt(params.clone()).unwrap();
+        let transaction = draft.transaction.clone();
+        check_draft_tx_match_params(draft, params.clone());
+
+        let draft = account.compose_psbt(params.clone()).unwrap();
+        check_draft_tx_match_params(draft, params.clone());
+
+        account.persist().unwrap();
+        let post_compose_indexes = account.get_derivation_index();
+
+        // Verify derivation indexes remain unchanged,
+        assert_eq!(initial_indexes, post_compose_indexes);
+
+        // verify transaction properties
+        assert_eq!(transaction.amount, -1000);
+        assert_eq!(transaction.address, address);
+        assert_eq!(transaction.fee_rate, 2);
+        assert_eq!(transaction.note, params.note);
+        assert_eq!(transaction.get_change_tag(), params.tag);
+    }
+
     #[test]
     #[cfg(feature = "envoy")]
     fn test_rbf() {


### PR DESCRIPTION
uses Address::eq for more reliable
address matching when calculating transaction amount for bitcoin tx. and test cases for this change