### PR TITLE
NgAccountConfig improvements

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -702,6 +702,7 @@ pub struct NgAccountConfig {
     pub network: Network,
     pub id: String,
     pub multisig: Option<MultiSigDetails>,
+    pub archived: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -780,6 +781,7 @@ impl<P: WalletPersister> Default for NgAccountBuilder<P> {
             date_synced: None,
             seed_has_passphrase: None,
             multisig: None,
+            archived: None,
         }
     }
 }
@@ -798,6 +800,7 @@ pub struct NgAccountBuilder<P: WalletPersister> {
     date_synced: Option<String>,
     seed_has_passphrase: Option<bool>,
     multisig: Option<MultiSigDetails>,
+    archived: Option<bool>,
 }
 
 impl<P: WalletPersister> NgAccountBuilder<P> {
@@ -917,6 +920,7 @@ impl<P: WalletPersister> NgAccountBuilder<P> {
             date_synced: self.date_synced,
             seed_has_passphrase: self.seed_has_passphrase.unwrap_or(false),
             multisig: self.multisig,
+            archived: self.archived.unwrap_or_default(),
         };
 
         NgAccount::new_from_descriptors(ng_account_config, Arc::new(meta_storage), descriptors)

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,7 +3,6 @@ use crate::store::MetaStorage;
 use anyhow::{Context, Result};
 use bdk_wallet::KeychainKind;
 use redb::{Builder, Database, ReadableTable, TableDefinition};
-use std::sync::Arc;
 
 const FEE_TABLE: TableDefinition<&str, u64> = TableDefinition::new("fees");
 
@@ -18,9 +17,9 @@ const ACCOUNT_CONFIG: TableDefinition<&str, &str> = TableDefinition::new("config
 const LAST_VERIFIED_ADDRESS_TABLE: TableDefinition<&str, u32> =
     TableDefinition::new("last_verified_address");
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RedbMetaStorage {
-    db: Arc<Database>,
+    db: Database,
 }
 
 impl RedbMetaStorage {
@@ -35,11 +34,11 @@ impl RedbMetaStorage {
                 .with_context(|| "Failed to create redb database")?
         };
 
-        Ok(RedbMetaStorage { db: Arc::new(db) })
+        Ok(RedbMetaStorage { db })
     }
 
     pub fn from_db(db: Database) -> Self {
-        Self { db: Arc::new(db) }
+        Self { db }
     }
 
     //TODO: fix persist

--- a/src/db.rs
+++ b/src/db.rs
@@ -18,7 +18,7 @@ const ACCOUNT_CONFIG: TableDefinition<&str, &str> = TableDefinition::new("config
 const LAST_VERIFIED_ADDRESS_TABLE: TableDefinition<&str, u32> =
     TableDefinition::new("last_verified_address");
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RedbMetaStorage {
     db: Arc<Database>,
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,7 +2,7 @@ use crate::config::{AddressType, NgAccountConfig};
 use crate::store::MetaStorage;
 use anyhow::{Context, Result};
 use bdk_wallet::KeychainKind;
-use redb::{Builder, Database, ReadableTable, StorageBackend, TableDefinition};
+use redb::{Builder, Database, ReadableTable, TableDefinition};
 use std::sync::Arc;
 
 const FEE_TABLE: TableDefinition<&str, u64> = TableDefinition::new("fees");
@@ -38,11 +38,8 @@ impl RedbMetaStorage {
         Ok(RedbMetaStorage { db: Arc::new(db) })
     }
 
-    pub fn from_backend(backend: impl StorageBackend) -> anyhow::Result<Self> {
-        let db = Builder::new()
-            .create_with_backend(backend)
-            .with_context(|| "Failed to create database")?;
-        Ok(RedbMetaStorage { db: Arc::new(db) })
+    pub fn from_db(db: Database) -> Self {
+        Self { db: Arc::new(db) }
     }
 
     //TODO: fix persist

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod config;
 pub mod ngwallet;
 pub mod rbf;
 pub mod send;
-mod store;
+pub mod store;
 pub mod transaction;
 pub mod utxo;
 
@@ -11,7 +11,7 @@ pub use bdk_wallet;
 pub use redb;
 
 pub mod bip39;
-mod db;
+pub mod db;
 pub mod utils;
 
 #[cfg(feature = "envoy")]


### PR DESCRIPTION
- MetaStorage trait is public now. this enables reusing the redb instance when transitioning between the initially loaded NgAccountConfig -> full NgAccount in KeyOS
- removed the `StorageBackend` constructors in favor of explicitly providing a redb::Database instance or a custom MetaStorage, which is more configurable (e.g. cache size) for keyos constrained runtime
- Multisig fingerprints are now using bytes instead of string representation
- new `archived: bool` field in NgAccountConfig