### PR TITLE
Add default value for archived  in config for Envoy compatibility.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -714,6 +714,7 @@ pub struct NgAccountConfig {
     pub network: Network,
     pub id: String,
     pub multisig: Option<MultiSigDetails>,
+    #[serde(default)]
     pub archived: bool,
 }
 


### PR DESCRIPTION
 “archived” field doesn’t exist in older versions of envoy. 