### PR TITLE
[AI] fix(ENV-2275): lower is_confirmed threshold to 1 confirmation

### DIFF
--- a/src/ngwallet.rs
+++ b/src/ngwallet.rs
@@ -246,7 +246,7 @@ impl<P: WalletPersister> NgWallet<P> {
                                 }
                             }),
                         date,
-                        is_confirmed: confirmations >= 3,
+                        is_confirmed: confirmations >= 1,
                     }
                 })
                 .collect::<Vec<Output>>();
@@ -363,7 +363,7 @@ impl<P: WalletPersister> NgWallet<P> {
                 tx_id: tx_id.clone(),
                 block_height,
                 confirmations,
-                is_confirmed: confirmations >= 3,
+                is_confirmed: confirmations >= 1,
                 fee,
                 fee_rate,
                 amount,
@@ -532,7 +532,7 @@ impl<P: WalletPersister> NgWallet<P> {
                     .unwrap_or(None),
                 do_not_spend,
                 date,
-                is_confirmed: confirmations >= 3,
+                is_confirmed: confirmations >= 1,
             });
         }
         Ok(unspents)

--- a/tests/ng_tests.rs
+++ b/tests/ng_tests.rs
@@ -451,6 +451,41 @@ mod tests {
 
     #[test]
     #[cfg(feature = "envoy")]
+    fn one_confirmation_is_confirmed() {
+        // Regression guard for the is_confirmed contract (ENV-2275): a tx
+        // anchored at the tip has exactly 1 confirmation and must be
+        // reported as confirmed on both surfaces (transactions() and utxos()).
+        let mut account = utils::tests_util::get_ng_hot_wallet();
+        utils::tests_util::add_funds_wallet_with_one_confirmation(&mut account);
+
+        let txs = account.transactions().unwrap();
+        assert!(!txs.is_empty(), "expected at least one transaction");
+        for tx in &txs {
+            assert_eq!(
+                tx.confirmations, 1,
+                "tx {} should have exactly 1 confirmation",
+                tx.tx_id
+            );
+            assert!(
+                tx.is_confirmed,
+                "tx {} with 1 confirmation should have is_confirmed=true",
+                tx.tx_id
+            );
+        }
+
+        let utxos = account.utxos().unwrap();
+        assert!(!utxos.is_empty(), "expected at least one utxo");
+        for output in &utxos {
+            assert!(
+                output.is_confirmed,
+                "utxo {}:{} with 1 confirmation should have is_confirmed=true",
+                output.tx_id, output.vout
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "envoy")]
     fn check_psbt_parsing() {
         let mut account = utils::tests_util::get_ng_watch_only_account();
         utils::tests_util::add_funds_to_wallet(&mut account);

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -104,6 +104,14 @@ pub mod tests_util {
         fill_with_unconfirmed(&account.get_coordinator_wallet());
     }
 
+    pub fn add_funds_wallet_with_one_confirmation<P: WalletPersister>(
+        account: &mut NgAccount<P>,
+    ) {
+        for (index, ngwallet) in account.wallets.read().unwrap().iter().enumerate() {
+            fill_with_one_confirmation(index, &ngwallet)
+        }
+    }
+
     fn fill_with_unconfirmed<P: WalletPersister>(ngwallet: &NgWallet<P>) {
         let mut wallet = ngwallet.bdk_wallet.lock().unwrap();
         let to_address =
@@ -166,6 +174,48 @@ pub mod tests_util {
             &mut wallet,
             BlockId {
                 height: 2_000,
+                hash: BlockHash::all_zeros(),
+            },
+        );
+
+        bdk_wallet::test_utils::insert_tx(&mut wallet, tx0.clone());
+        bdk_wallet::test_utils::insert_anchor(
+            &mut wallet,
+            tx0.compute_txid(),
+            ConfirmationBlockTime {
+                block_id: BlockId {
+                    height: 1_000,
+                    hash: BlockHash::all_zeros(),
+                },
+                confirmation_time: 100,
+            },
+        );
+    }
+
+    // Anchors the tx at the tip so `tip_height - block_height + 1 == 1`.
+    fn fill_with_one_confirmation<P: WalletPersister>(index: usize, ngwallet: &&NgWallet<P>) {
+        let amounts = [76_000, 25_000];
+        let mut wallet = ngwallet.bdk_wallet.lock().unwrap();
+        let receive_address = wallet.next_unused_address(KeychainKind::External).address;
+
+        let tx0 = Transaction {
+            output: vec![TxOut {
+                value: Amount::from_sat(amounts[index]),
+                script_pubkey: receive_address.script_pubkey(),
+            }],
+            ..new_tx(0)
+        };
+        bdk_wallet::test_utils::insert_checkpoint(
+            &mut wallet,
+            BlockId {
+                height: 42,
+                hash: BlockHash::all_zeros(),
+            },
+        );
+        bdk_wallet::test_utils::insert_checkpoint(
+            &mut wallet,
+            BlockId {
+                height: 1_000,
                 hash: BlockHash::all_zeros(),
             },
         );


### PR DESCRIPTION
## Summary

Change `is_confirmed = confirmations >= 3` to `>= 1` at all three sites in `src/ngwallet.rs`:

- L249 — `Output` in the UTXO mapping
- L366 — `BitcoinTransaction`
- L535 — `Output` in the unspents list

## Why

Envoy surfaces "Awaiting Confirmation" until `is_confirmed` flips to true. With the threshold at 3, a tx that has already confirmed once still shows as pending for ~20–30 minutes (avg block time ≈ 10 min) — the exact symptom in [ENV-2275](https://linear.app/foundation-devices/issue/ENV-2275/transaction-status-not-updating).

One confirmation is a strong enough signal for the confirmed-in-a-block badge. Deeper-confirmation semantics (spendability, high-value receive policy, etc.) should live in higher-level policy, not in this boolean.

## Companion PR

[envoy-dev #1239](https://github.com/Foundation-Devices/envoy-dev/pull/1239) re-routes `filteredTransactionsProvider` to read `isConfirmed` directly instead of re-implementing the threshold in Dart — so once this PR tags a new release and envoy-dev bumps the pin, the fix propagates automatically.

## Test plan

- [ ] `cargo test` passes.
- [ ] Manual: a tx with 1 confirmation reports `is_confirmed = true` in consumer apps.
- [ ] No regression in `BitcoinTransaction` serialization (field type unchanged, just the computed value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)