### PR TITLE
[AI] config: accept crypto-output UR for multisig import (SFT-6915)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,12 +340,12 @@ checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
 [[package]]
 name = "foundation-arena"
 version = "0.1.0"
-source = "git+https://github.com/Foundation-Devices/foundation-rs.git?rev=311c83e1647842f10ee7e92bbf9950d4d17b1a3f#311c83e1647842f10ee7e92bbf9950d4d17b1a3f"
+source = "git+https://github.com/Foundation-Devices/foundation-rs.git?tag=0.6.0#99b00a3d62043391416b5ea438a50e598b1fb1dd"
 
 [[package]]
 name = "foundation-urtypes"
 version = "0.5.0"
-source = "git+https://github.com/Foundation-Devices/foundation-rs.git?rev=311c83e1647842f10ee7e92bbf9950d4d17b1a3f#311c83e1647842f10ee7e92bbf9950d4d17b1a3f"
+source = "git+https://github.com/Foundation-Devices/foundation-rs.git?tag=0.6.0#99b00a3d62043391416b5ea438a50e598b1fb1dd"
 dependencies = [
  "faster-hex",
  "foundation-arena",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,12 +340,12 @@ checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
 [[package]]
 name = "foundation-arena"
 version = "0.1.0"
-source = "git+https://github.com/Jacksper13/foundation-rs?branch=jack%2Fsft-6915-decode-crypto-output#b45065dba33ffd50a32e6186d2103c6a821c4dc3"
+source = "git+https://github.com/Jacksper13/foundation-rs?rev=3289111dac2d1cf50e8447d02cd703cf31eb5168#3289111dac2d1cf50e8447d02cd703cf31eb5168"
 
 [[package]]
 name = "foundation-urtypes"
 version = "0.5.0"
-source = "git+https://github.com/Jacksper13/foundation-rs?branch=jack%2Fsft-6915-decode-crypto-output#b45065dba33ffd50a32e6186d2103c6a821c4dc3"
+source = "git+https://github.com/Jacksper13/foundation-rs?rev=3289111dac2d1cf50e8447d02cd703cf31eb5168#3289111dac2d1cf50e8447d02cd703cf31eb5168"
 dependencies = [
  "faster-hex",
  "foundation-arena",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,12 +340,12 @@ checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
 [[package]]
 name = "foundation-arena"
 version = "0.1.0"
-source = "git+https://github.com/Jacksper13/foundation-rs?rev=3289111dac2d1cf50e8447d02cd703cf31eb5168#3289111dac2d1cf50e8447d02cd703cf31eb5168"
+source = "git+https://github.com/Foundation-Devices/foundation-rs.git?rev=311c83e1647842f10ee7e92bbf9950d4d17b1a3f#311c83e1647842f10ee7e92bbf9950d4d17b1a3f"
 
 [[package]]
 name = "foundation-urtypes"
 version = "0.5.0"
-source = "git+https://github.com/Jacksper13/foundation-rs?rev=3289111dac2d1cf50e8447d02cd703cf31eb5168#3289111dac2d1cf50e8447d02cd703cf31eb5168"
+source = "git+https://github.com/Foundation-Devices/foundation-rs.git?rev=311c83e1647842f10ee7e92bbf9950d4d17b1a3f#311c83e1647842f10ee7e92bbf9950d4d17b1a3f"
 dependencies = [
  "faster-hex",
  "foundation-arena",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+
+[[package]]
+name = "foundation-arena"
+version = "0.1.0"
+source = "git+https://github.com/Jacksper13/foundation-rs?branch=jack%2Fsft-6915-decode-crypto-output#b45065dba33ffd50a32e6186d2103c6a821c4dc3"
+
+[[package]]
+name = "foundation-urtypes"
+version = "0.5.0"
+source = "git+https://github.com/Jacksper13/foundation-rs?branch=jack%2Fsft-6915-decode-crypto-output#b45065dba33ffd50a32e6186d2103c6a821c4dc3"
+dependencies = [
+ "faster-hex",
+ "foundation-arena",
+ "heapless",
+ "minicbor 0.24.4",
+ "uuid",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +373,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -381,6 +413,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -461,11 +503,31 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minicbor"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29be4f60e41fde478b36998b88821946aafac540e53591e76db53921a0cc225b"
+dependencies = [
+ "minicbor-derive 0.15.3",
+]
+
+[[package]]
+name = "minicbor"
 version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a309f581ade7597820083bc275075c4c6986e57e53f8d26f88507cfefc8c987"
 dependencies = [
- "minicbor-derive",
+ "minicbor-derive 0.16.2",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -485,7 +547,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e45e8beeefea1b8b6f52fa188a5b6ea3746c2885606af8d4d8bf31cee633fb"
 dependencies = [
- "minicbor",
+ "minicbor 0.26.5",
  "serde",
 ]
 
@@ -531,7 +593,10 @@ dependencies = [
  "bip39",
  "bip85",
  "bitcoin",
+ "foundation-arena",
+ "foundation-urtypes",
  "log",
+ "minicbor 0.24.4",
  "minicbor-serde",
  "redb",
  "regex",
@@ -874,6 +939,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,12 @@ sha2 = { version = "0.10.9", optional = true }
 thiserror = "2.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 bitcoin = { version = "0.32", features = ["secp-recovery"], default-features = false }
+# SFT-6915: pin to the fork branch until foundation-rs PR #54 lands.
+foundation-urtypes = { git = "https://github.com/Jacksper13/foundation-rs", branch = "jack/sft-6915-decode-crypto-output", default-features = false, features = ["alloc"] }
+foundation-arena = { git = "https://github.com/Jacksper13/foundation-rs", branch = "jack/sft-6915-decode-crypto-output" }
+
+[dev-dependencies]
+minicbor = { version = "0.24", features = ["alloc"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ sha2 = { version = "0.10.9", optional = true }
 thiserror = "2.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 bitcoin = { version = "0.32", features = ["secp-recovery"], default-features = false }
-foundation-urtypes = { git = "https://github.com/Foundation-Devices/foundation-rs.git", rev = "311c83e1647842f10ee7e92bbf9950d4d17b1a3f", default-features = false, features = ["alloc"] }
+foundation-urtypes = { git = "https://github.com/Foundation-Devices/foundation-rs.git", tag = "0.6.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 minicbor = { version = "0.24", features = ["alloc"] }
 # Only used inside `#[cfg(test)]` helpers in `src/config.rs` (the
 # crypto-output CBOR encoder/decoder tests); keep it out of the
 # production dep graph.
-foundation-arena = { git = "https://github.com/Foundation-Devices/foundation-rs.git", rev = "311c83e1647842f10ee7e92bbf9950d4d17b1a3f" }
+foundation-arena = { git = "https://github.com/Foundation-Devices/foundation-rs.git", tag = "0.6.0" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,17 @@ sha2 = { version = "0.10.9", optional = true }
 thiserror = "2.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 bitcoin = { version = "0.32", features = ["secp-recovery"], default-features = false }
-# SFT-6915: pin to the fork branch until foundation-rs PR #54 lands.
-foundation-urtypes = { git = "https://github.com/Jacksper13/foundation-rs", branch = "jack/sft-6915-decode-crypto-output", default-features = false, features = ["alloc"] }
-foundation-arena = { git = "https://github.com/Jacksper13/foundation-rs", branch = "jack/sft-6915-decode-crypto-output" }
+# SFT-6915: pin to a fixed rev on the fork until foundation-rs PR #54
+# lands (per reviewer request — keeps downstream builds reproducible
+# instead of floating with the branch tip).
+foundation-urtypes = { git = "https://github.com/Jacksper13/foundation-rs", rev = "3289111dac2d1cf50e8447d02cd703cf31eb5168", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 minicbor = { version = "0.24", features = ["alloc"] }
+# Only used inside `#[cfg(test)]` helpers in `src/config.rs` (the
+# crypto-output CBOR encoder/decoder tests); keep it out of the
+# production dep graph.
+foundation-arena = { git = "https://github.com/Jacksper13/foundation-rs", rev = "3289111dac2d1cf50e8447d02cd703cf31eb5168" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,14 @@ sha2 = { version = "0.10.9", optional = true }
 thiserror = "2.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 bitcoin = { version = "0.32", features = ["secp-recovery"], default-features = false }
-# SFT-6915: pin to a fixed rev on the fork until foundation-rs PR #54
-# lands (per reviewer request — keeps downstream builds reproducible
-# instead of floating with the branch tip).
-foundation-urtypes = { git = "https://github.com/Jacksper13/foundation-rs", rev = "3289111dac2d1cf50e8447d02cd703cf31eb5168", default-features = false, features = ["alloc"] }
+foundation-urtypes = { git = "https://github.com/Foundation-Devices/foundation-rs.git", rev = "311c83e1647842f10ee7e92bbf9950d4d17b1a3f", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 minicbor = { version = "0.24", features = ["alloc"] }
 # Only used inside `#[cfg(test)]` helpers in `src/config.rs` (the
 # crypto-output CBOR encoder/decoder tests); keep it out of the
 # production dep graph.
-foundation-arena = { git = "https://github.com/Jacksper13/foundation-rs", rev = "3289111dac2d1cf50e8447d02cd703cf31eb5168" }
+foundation-arena = { git = "https://github.com/Foundation-Devices/foundation-rs.git", rev = "311c83e1647842f10ee7e92bbf9950d4d17b1a3f" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,9 +15,14 @@ use crate::store::MetaStorage;
 use crate::utils::get_address_type;
 use bdk_wallet::KeychainKind;
 use bdk_wallet::WalletPersister;
-use bdk_wallet::bitcoin::bip32::{self, ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
-use bdk_wallet::bitcoin::secp256k1::{Secp256k1, Signing};
-use bdk_wallet::bitcoin::{self, Network};
+use bdk_wallet::bitcoin::bip32::{
+    self, ChainCode, ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub,
+};
+use bdk_wallet::bitcoin::secp256k1::{PublicKey, Secp256k1, Signing};
+use bdk_wallet::bitcoin::{self, Network, NetworkKind as BtcNetworkKind};
+use foundation_urtypes::registry::{
+    ChildNumber as UrChildNumber, HDKeyRef, Key as UrKey, Terminal,
+};
 use bdk_wallet::descriptor::Descriptor as BdkDescriptor;
 use bdk_wallet::miniscript::{
     ForEachKey,
@@ -452,6 +457,72 @@ impl MultiSigDetails {
         Ok((res, name))
     }
 
+    /// Build a [`MultiSigDetails`] from a decoded `crypto-output`
+    /// ([`foundation_urtypes::registry::Terminal`]) descriptor tree.
+    ///
+    /// Callers obtain `terminal` from
+    /// `foundation_urtypes::value::decode_output_descriptor`. This path is
+    /// what lets Prime import animated multisig QRs from wallets like
+    /// Sparrow that emit `ur:crypto-output/...` frames rather than the
+    /// text-config or string-descriptor formats.
+    ///
+    /// Accepted shapes (mirroring [`Self::from_descriptor`]):
+    /// - `wsh(sortedmulti(M, xpub1, xpub2, ...))` → `P2wsh`
+    /// - `sh(wsh(sortedmulti(M, xpub1, xpub2, ...)))` → `P2ShWsh`
+    ///
+    /// Non-sorted `multisig`, taproot, bare addresses, raw scripts, and any
+    /// other descriptor shapes are rejected — Prime doesn't support them
+    /// today and accepting them here would let an import succeed that would
+    /// later fail at spend time.
+    pub fn from_crypto_output(
+        terminal: &Terminal<'_, '_>,
+    ) -> Result<(Self, String), anyhow::Error> {
+        let (format, multikey) = match terminal {
+            Terminal::WitnessScriptHash(inner) => match &**inner {
+                Terminal::SortedMultisig(mk) => (AddressType::P2wsh, mk),
+                Terminal::Multisig(_) => anyhow::bail!(
+                    "crypto-output multisig must be sorted (sortedmulti), got unsorted multi"
+                ),
+                _ => anyhow::bail!(
+                    "crypto-output wsh() must wrap sortedmulti, other scripts are not accepted"
+                ),
+            },
+            Terminal::ScriptHash(outer) => match &**outer {
+                Terminal::WitnessScriptHash(inner) => match &**inner {
+                    Terminal::SortedMultisig(mk) => (AddressType::P2ShWsh, mk),
+                    Terminal::Multisig(_) => anyhow::bail!(
+                        "crypto-output multisig must be sorted (sortedmulti), got unsorted multi"
+                    ),
+                    _ => anyhow::bail!(
+                        "crypto-output sh(wsh()) must wrap sortedmulti, other scripts are not accepted"
+                    ),
+                },
+                _ => anyhow::bail!(
+                    "crypto-output sh() must wrap wsh(sortedmulti), other scripts are not accepted"
+                ),
+            },
+            _ => anyhow::bail!(
+                "crypto-output descriptors must be wsh(sortedmulti) or sh(wsh(sortedmulti))"
+            ),
+        };
+
+        let signers: Vec<MultiSigSigner> = multikey
+            .keys
+            .iter()
+            .map(|k| hdkey_to_signer(&k))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let res = Self::new(
+            multikey.threshold as usize,
+            signers.len(),
+            format,
+            None,
+            signers,
+        )?;
+        let name = res.default_name();
+        Ok((res, name))
+    }
+
     pub fn from_descriptor(descriptor: &str) -> Result<(Self, String), anyhow::Error> {
         let descriptor = BdkDescriptor::<DescriptorPublicKey>::from_str(descriptor)?;
 
@@ -627,6 +698,100 @@ impl MultiSigDetails {
 
         hasher.finalize().into()
     }
+}
+
+/// Convert a `foundation-urtypes` key entry into a [`MultiSigSigner`].
+///
+/// We walk the CBOR-decoded view (`DerivedKeyRef` + `KeypathRef`) and
+/// reconstruct a `bitcoin::bip32::Xpub` from its raw bytes so downstream
+/// code can treat it identically to xpubs coming from text-config or
+/// string-descriptor imports.
+fn hdkey_to_signer(key: &UrKey<'_>) -> Result<MultiSigSigner, anyhow::Error> {
+    let hdkey = match key {
+        UrKey::HDKey(h) => h,
+        UrKey::ECKey(_) => {
+            anyhow::bail!("crypto-output multisig key is a bare EC pubkey; need an hdkey/xpub")
+        }
+    };
+    let derived = match hdkey {
+        HDKeyRef::DerivedKey(d) => d,
+        HDKeyRef::MasterKey(_) => {
+            anyhow::bail!("crypto-output multisig key is a master key; need a derived xpub")
+        }
+    };
+
+    let origin = derived
+        .origin
+        .as_ref()
+        .context("crypto-output hdkey is missing origin info (need master fingerprint + path)")?;
+
+    let src_fp = origin
+        .source_fingerprint
+        .context("crypto-output hdkey origin is missing source-fingerprint")?;
+    let master_fingerprint = Fingerprint::from(src_fp.get().to_be_bytes());
+
+    let mut path_components: Vec<ChildNumber> = Vec::with_capacity(origin.components.len());
+    for comp in origin.components.iter() {
+        let index = match comp.number {
+            UrChildNumber::Number(n) => n,
+            UrChildNumber::Range(_) => {
+                anyhow::bail!("crypto-output hdkey origin contains a wildcard path component")
+            }
+        };
+        path_components.push(if comp.is_hardened {
+            ChildNumber::Hardened { index }
+        } else {
+            ChildNumber::Normal { index }
+        });
+    }
+    let derivation_path = DerivationPath::from(path_components.clone());
+
+    let chain_code_bytes = derived
+        .chain_code
+        .context("crypto-output hdkey is missing chain code")?;
+
+    let public_key = PublicKey::from_slice(&derived.key_data)
+        .context("crypto-output hdkey has invalid compressed pubkey")?;
+
+    // CoinInfo network is the BIP44 SLIP-44-ish value: 0 = mainnet, 1 = testnet.
+    // Absent → default to mainnet (matches `from_sorted_multi` which also
+    // defers network inference to `Self::new`).
+    let network = match derived.use_info.as_ref().map(|ci| ci.network) {
+        Some(0) | None => BtcNetworkKind::Main,
+        Some(1) => BtcNetworkKind::Test,
+        Some(other) => {
+            anyhow::bail!("crypto-output hdkey has unsupported network index {other}")
+        }
+    };
+
+    let depth = origin
+        .depth
+        .unwrap_or_else(|| origin.components.len() as u8);
+
+    let parent_fingerprint = derived
+        .parent_fingerprint
+        .map(|fp| Fingerprint::from(fp.get().to_be_bytes()))
+        .unwrap_or_default();
+
+    let child_number = path_components
+        .last()
+        .copied()
+        .unwrap_or(ChildNumber::Normal { index: 0 });
+
+    let xpub = Xpub {
+        network,
+        depth,
+        parent_fingerprint,
+        child_number,
+        public_key,
+        chain_code: ChainCode::from(chain_code_bytes),
+    };
+
+    Ok(MultiSigSigner::new(
+        &derivation_path,
+        &master_fingerprint,
+        &xpub,
+    ))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -1324,6 +1489,199 @@ Format: P2WSH
         let zpub = bitcoin::base58::encode_check(&bytes);
         assert!(zpub.starts_with("zpub"));
         assert_eq!(normalize_slip132(&zpub), zpub);
+    }
+
+    // Build a `Terminal::WitnessScriptHash(SortedMultisig(...))` tree from
+    // `(xpub_str, fingerprint_hex, derivation_str)` entries, encode it to
+    // CBOR, and return the bytes plus the byte-backing storage. Mirrors
+    // what `minicbor::to_vec(&Terminal)` gives us when the sender is
+    // e.g. Sparrow.
+    #[cfg(test)]
+    fn encode_wsh_sortedmulti_cbor(
+        threshold: u8,
+        entries: &[(&str, [u8; 4], &str)],
+    ) -> Vec<u8> {
+        use foundation_arena::boxed::Box as ArenaBox;
+        use foundation_urtypes::registry::{
+            CoinInfo, CoinType, DerivedKeyRef, HDKeyRef as UrHDKeyRef, Key, KeypathRef, Keys,
+            Multikey, PathComponents, Terminal, TerminalContext,
+        };
+        use std::num::NonZeroU32;
+
+        // Pre-decompose each entry into stable byte storage that outlives
+        // every borrow below.
+        struct Entry {
+            key_data: [u8; 33],
+            chain_code: [u8; 32],
+            path_raw: Vec<u32>,
+            source_fingerprint: NonZeroU32,
+            parent_fingerprint: Option<NonZeroU32>,
+            depth: u8,
+        }
+        let decomposed: Vec<Entry> = entries
+            .iter()
+            .map(|(xpub_str, xfp, deriv)| {
+                let xpub = Xpub::from_str(xpub_str).unwrap();
+                let deriv_path = DerivationPath::from_str(deriv).unwrap();
+                let path_raw: Vec<u32> = deriv_path
+                    .into_iter()
+                    .map(|cn| match cn {
+                        ChildNumber::Normal { index } => *index,
+                        ChildNumber::Hardened { index } => *index | (1 << 31),
+                    })
+                    .collect();
+                Entry {
+                    key_data: xpub.public_key.serialize(),
+                    chain_code: xpub.chain_code.to_bytes(),
+                    path_raw,
+                    source_fingerprint: NonZeroU32::new(u32::from_be_bytes(*xfp)).unwrap(),
+                    parent_fingerprint: NonZeroU32::new(u32::from_be_bytes(
+                        xpub.parent_fingerprint.to_bytes(),
+                    )),
+                    depth: xpub.depth,
+                }
+            })
+            .collect();
+
+        let arena: TerminalContext<4> = TerminalContext::new();
+        let keys_owned: Vec<Key> = decomposed
+            .iter()
+            .map(|e| {
+                Key::HDKey(UrHDKeyRef::DerivedKey(DerivedKeyRef {
+                    is_private: false,
+                    key_data: e.key_data,
+                    chain_code: Some(e.chain_code),
+                    use_info: Some(CoinInfo::new(CoinType::BTC, CoinInfo::NETWORK_MAINNET)),
+                    origin: Some(KeypathRef {
+                        components: PathComponents::from(e.path_raw.as_slice()),
+                        source_fingerprint: Some(e.source_fingerprint),
+                        depth: Some(e.depth),
+                    }),
+                    children: None,
+                    parent_fingerprint: e.parent_fingerprint,
+                    name: None,
+                    note: None,
+                }))
+            })
+            .collect();
+        let keys = Keys::from(keys_owned.as_slice());
+        let sortedmulti = ArenaBox::new_in(
+            Terminal::SortedMultisig(Multikey { threshold, keys }),
+            &arena,
+        )
+        .unwrap();
+        let root = Terminal::WitnessScriptHash(sortedmulti);
+        minicbor::to_vec(&root).unwrap()
+    }
+
+    #[test]
+    fn multisig_from_crypto_output_wsh_sortedmulti() {
+        use foundation_urtypes::registry::TerminalContext;
+        use foundation_urtypes::value::decode_output_descriptor;
+
+        // Same signer set as `multisig_from_descriptor_1`.
+        let entries: &[(&str, [u8; 4], &str)] = &[
+            (
+                "xpub6ESpvmZa75rCQWKik2KoCZrjTi6xhSubZKJ25rbtgZRk2g9tZTJqubhaGD3dJeqruw9KMCaanoEfJ1PVtBXiwTuuqLVwk9ucqkRv1sKWiEC",
+                [0x71, 0xC8, 0xBD, 0x85],
+                "m/48'/0'/0'/2'",
+            ),
+            (
+                "xpub6EPJuK8Ejz82nKc7PsRgcYqdcQH9G1ZikCTasr9i79CbXxMMiPfxEyA14S6HPTHufmcQR7x8t5L3BP9tRfm9EBRBPic2xV892j9z4ePESae",
+                [0xAB, 0x88, 0xDE, 0x89],
+                "m/48'/0'/0'/2'",
+            ),
+            (
+                "xpub6FQY5W8WygMVYY2nTP188jFHNdZfH2t9qtcS8SPpFatUGiciqUsGZpNvEa1oABEyeAsrUL2XSnvuRUdrhf5LcMXcjhrUFBcneBYYZzky3Mc",
+                [0xA9, 0xF9, 0x96, 0x4A],
+                "m/48'/0'/0'/2'",
+            ),
+        ];
+
+        let cbor = encode_wsh_sortedmulti_cbor(2, entries);
+
+        let arena: TerminalContext<4> = TerminalContext::new();
+        let terminal = decode_output_descriptor("crypto-output", &cbor, &arena).unwrap();
+        let (multisig, name) = MultiSigDetails::from_crypto_output(&terminal).unwrap();
+
+        let expected = MultiSigDetails::new(
+            2,
+            3,
+            AddressType::P2wsh,
+            Some(NetworkKind::Main),
+            vec![
+                MultiSigSigner {
+                    derivation: String::from("m/48'/0'/0'/2'"),
+                    fingerprint: [0x71, 0xC8, 0xBD, 0x85],
+                    pubkey: String::from("xpub6ESpvmZa75rCQWKik2KoCZrjTi6xhSubZKJ25rbtgZRk2g9tZTJqubhaGD3dJeqruw9KMCaanoEfJ1PVtBXiwTuuqLVwk9ucqkRv1sKWiEC"),
+                },
+                MultiSigSigner {
+                    derivation: String::from("m/48'/0'/0'/2'"),
+                    fingerprint: [0xAB, 0x88, 0xDE, 0x89],
+                    pubkey: String::from("xpub6EPJuK8Ejz82nKc7PsRgcYqdcQH9G1ZikCTasr9i79CbXxMMiPfxEyA14S6HPTHufmcQR7x8t5L3BP9tRfm9EBRBPic2xV892j9z4ePESae"),
+                },
+                MultiSigSigner {
+                    derivation: String::from("m/48'/0'/0'/2'"),
+                    fingerprint: [0xA9, 0xF9, 0x96, 0x4A],
+                    pubkey: String::from("xpub6FQY5W8WygMVYY2nTP188jFHNdZfH2t9qtcS8SPpFatUGiciqUsGZpNvEa1oABEyeAsrUL2XSnvuRUdrhf5LcMXcjhrUFBcneBYYZzky3Mc"),
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(multisig, expected);
+        assert_eq!("Multisig-2-of-3-Main", name);
+    }
+
+    #[test]
+    fn multisig_from_crypto_output_rejects_unsorted_multi() {
+        use foundation_arena::boxed::Box as ArenaBox;
+        use foundation_urtypes::registry::{
+            CoinInfo, CoinType, DerivedKeyRef, HDKeyRef as UrHDKeyRef, Key, KeypathRef, Keys,
+            Multikey, PathComponents, Terminal, TerminalContext,
+        };
+        use std::num::NonZeroU32;
+
+        // Hand-roll an unsorted `multi(...)` — our validator must reject
+        // even if the rest of the shape is otherwise identical to a valid
+        // sortedmulti.
+        let xpub = Xpub::from_str(
+            "xpub6ESpvmZa75rCQWKik2KoCZrjTi6xhSubZKJ25rbtgZRk2g9tZTJqubhaGD3dJeqruw9KMCaanoEfJ1PVtBXiwTuuqLVwk9ucqkRv1sKWiEC"
+        )
+        .unwrap();
+        let key_data = xpub.public_key.serialize();
+        let chain_code = xpub.chain_code.to_bytes();
+        let path_raw: Vec<u32> = vec![48 | (1 << 31), 1 << 31, 1 << 31, 2 | (1 << 31)];
+        let source_fingerprint = NonZeroU32::new(u32::from_be_bytes([0x71, 0xC8, 0xBD, 0x85])).unwrap();
+
+        let arena: TerminalContext<4> = TerminalContext::new();
+        let k = Key::HDKey(UrHDKeyRef::DerivedKey(DerivedKeyRef {
+            is_private: false,
+            key_data,
+            chain_code: Some(chain_code),
+            use_info: Some(CoinInfo::new(CoinType::BTC, CoinInfo::NETWORK_MAINNET)),
+            origin: Some(KeypathRef {
+                components: PathComponents::from(path_raw.as_slice()),
+                source_fingerprint: Some(source_fingerprint),
+                depth: Some(4),
+            }),
+            children: None,
+            parent_fingerprint: NonZeroU32::new(u32::from_be_bytes(
+                xpub.parent_fingerprint.to_bytes(),
+            )),
+            name: None,
+            note: None,
+        }));
+        let keys_storage: &[Key] = &[k.clone(), k];
+        let keys = Keys::from(keys_storage);
+        let multi = ArenaBox::new_in(
+            Terminal::Multisig(Multikey { threshold: 2, keys }),
+            &arena,
+        )
+        .unwrap();
+        let root = Terminal::WitnessScriptHash(multi);
+
+        let err = MultiSigDetails::from_crypto_output(&root).unwrap_err();
+        assert!(err.to_string().contains("sortedmulti"), "err: {err}");
     }
 
     #[cfg(feature = "sha2")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -506,11 +506,25 @@ impl MultiSigDetails {
             ),
         };
 
-        let signers: Vec<MultiSigSigner> = multikey
-            .keys
-            .iter()
-            .map(|k| hdkey_to_signer(&k))
-            .collect::<Result<Vec<_>, _>>()?;
+        // Reject duplicate cosigner keys up front. `from_descriptor` catches
+        // this via miniscript's `sanity_check()`; `from_config` checks full-
+        // tuple equality on each parsed `MultiSigSigner`. Neither applies on
+        // this path — `Self::new` does not dedupe and
+        // `wsh(sortedmulti(2, X, X))` would otherwise import as a nominal
+        // 2-of-2 that spends with a single signature from X, silently
+        // collapsing the effective threshold. Compare on the pubkey string
+        // (the encoded xpub) so repeats of the same key under a different
+        // derivation annotation are also rejected.
+        let mut signers: Vec<MultiSigSigner> = Vec::new();
+        for k in multikey.keys.iter() {
+            let signer = hdkey_to_signer(&k)?;
+            if signers.iter().any(|existing| existing.pubkey == signer.pubkey) {
+                anyhow::bail!(
+                    "crypto-output multisig contains duplicate cosigner keys"
+                );
+            }
+            signers.push(signer);
+        }
 
         let res = Self::new(
             multikey.threshold as usize,
@@ -1682,6 +1696,32 @@ Format: P2WSH
 
         let err = MultiSigDetails::from_crypto_output(&root).unwrap_err();
         assert!(err.to_string().contains("sortedmulti"), "err: {err}");
+    }
+
+    #[test]
+    fn multisig_from_crypto_output_rejects_duplicate_cosigners() {
+        use foundation_urtypes::registry::TerminalContext;
+        use foundation_urtypes::value::decode_output_descriptor;
+
+        // `wsh(sortedmulti(2, X, X))` — the reviewer's PR #115 repro. Two
+        // identical cosigner keys collapse to a single signature at
+        // consensus, silently turning a nominal 2-of-2 into a 1-of-1. The
+        // descriptor path catches this via miniscript's `sanity_check()`;
+        // this path must reject it explicitly.
+        let xpub = "xpub6ESpvmZa75rCQWKik2KoCZrjTi6xhSubZKJ25rbtgZRk2g9tZTJqubhaGD3dJeqruw9KMCaanoEfJ1PVtBXiwTuuqLVwk9ucqkRv1sKWiEC";
+        let entries: &[(&str, [u8; 4], &str)] = &[
+            (xpub, [0x71, 0xC8, 0xBD, 0x85], "m/48'/0'/0'/2'"),
+            (xpub, [0x71, 0xC8, 0xBD, 0x85], "m/48'/0'/0'/2'"),
+        ];
+        let cbor = encode_wsh_sortedmulti_cbor(2, entries);
+
+        let arena: TerminalContext<4> = TerminalContext::new();
+        let terminal = decode_output_descriptor("crypto-output", &cbor, &arena).unwrap();
+        let err = MultiSigDetails::from_crypto_output(&terminal).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate cosigner"),
+            "err: {err}"
+        );
     }
 
     #[cfg(feature = "sha2")]


### PR DESCRIPTION
## Summary

Sparrow emits animated `ur:crypto-output/...` QRs for multisig descriptors (BCR-2020-010). Prime today has two entry points for multisig imports — `from_config` (BlueWallet/Coldcard text) and `from_descriptor` (miniscript strings) — but neither speaks CBOR, so these imports currently dead-end on KeyOS with `unsupported Uniform Resource type`.

Add `MultiSigDetails::from_crypto_output(&Terminal)` as a third entry point. Callers decode the UR payload with `foundation_urtypes::value::decode_output_descriptor` and hand the resulting `Terminal` tree here. Accepted shapes mirror `from_descriptor` exactly — `wsh(sortedmulti)` → `P2wsh` and `sh(wsh(sortedmulti))` → `P2ShWsh`. Unsorted `multi(...)`, taproot, bare addresses, and other shapes are rejected up front. Duplicate cosigner keys are rejected up front too (see round 2 below).

A file-private `hdkey_to_signer` walks each `HDKeyRef::DerivedKey`, pulls origin components + source fingerprint from the `KeypathRef`, reads the network from `CoinInfo`, and reconstructs a `bitcoin::bip32::Xpub` from the raw byte fields. Downstream `MultiSigDetails::new` then does the same threshold/network/format validation as the other paths, so things like 1-of-N (rejected since SFT-5584) and network mismatches produce identical errors across all three entry points.

## Review round 2

- **[P1] Reject duplicate cosigner keys.** The reviewer verified that `wsh(sortedmulti(2, X, X))` imported cleanly through `from_crypto_output`, silently collapsing a nominal 2-of-2 into a 1-of-1 at spending time. `from_descriptor` catches this via miniscript's `sanity_check()`; this path now does an explicit pubkey-string dedup before handing off to `Self::new`, with a regression test that replays the repro UR.
- **[P3] Moved `foundation-arena` to `[dev-dependencies]`.** It's only referenced from the `#[cfg(test)]` CBOR encoding helpers in `src/config.rs`, so downstream production builds no longer pull it.
- **Switched fork pins from `branch =` to `rev = 3289111...`** so downstream builds don't float with the branch tip. The rev also picks up the narrowed `is_output_descriptor` fix from foundation-rs PR #54 round 2.

## Dependency

Depends on foundation-rs PR #54 (https://github.com/Foundation-Devices/foundation-rs/pull/54) which exposes `decode_output_descriptor`. Until that lands, `foundation-urtypes` is pinned to the `3289111dac2d1cf50e8447d02cd703cf31eb5168` rev on the `Jacksper13/foundation-rs` fork. The pin will be repointed at upstream main once #54 merges.

## Context

This is PR 2 of 3 for SFT-6915:

1. foundation-rs PR #54 — expose the decode helper
2. **This PR** — ngwallet: add `from_crypto_output` consuming the helper
3. Foundation-Devices/KeyOS-dev#1679 — wire the `crypto-output` UR path through `create_account.rs`

Linear: https://linear.app/foundation-devices/issue/SFT-6915

## Test plan

- [x] `cargo test --lib config` — 16/16 pass (13 existing + 3 new: `multisig_from_crypto_output_wsh_sortedmulti`, `multisig_from_crypto_output_rejects_unsorted_multi`, `multisig_from_crypto_output_rejects_duplicate_cosigners`)
- [x] `cargo clippy --lib -- -D warnings` — clean
- [x] `cargo check --lib` — clean (confirms foundation-arena does NOT leak into the non-test build)
- [ ] End-to-end Sparrow → Prime animated QR import (tested via the KeyOS PR, not exercisable here)
- [ ] Draft — holding for review; will be taken out of draft once the foundation-rs helper is merged and the dep pin is repointed at upstream

## Out of scope

- BCR-2023-010 `output-descriptor` UR (tag 40308 map) — the upstream helper only handles the legacy `crypto-output` format; supporting the new flavor would need a separate v3 decoder in foundation-urtypes first
- Taproot multisig (`crypto-output` with tag 409) — Prime doesn't do taproot multisig yet
- `crypto-account` UR type — separate issue
- Actually wiring KeyOS — lives in the KeyOS-dev PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)