### PR TITLE
[AI] ENV-2575 fix(utils): propagate electrum client setup errors instead of panicking

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -633,7 +633,7 @@ impl<P: WalletPersister> NgAccount<P> {
         use bdk_wallet::bitcoin::Txid;
         use std::str::FromStr;
         let client =
-            utils::build_electrum_client(electrum_server, socks_proxy, validate_domain);
+            utils::build_electrum_client(electrum_server, socks_proxy, validate_domain).ok()?;
 
         let tx_id = Txid::from_str(txid).ok()?;
         let tx = client.fetch_tx(tx_id).ok()?;

--- a/src/account.rs
+++ b/src/account.rs
@@ -632,8 +632,9 @@ impl<P: WalletPersister> NgAccount<P> {
     ) -> Option<u64> {
         use bdk_wallet::bitcoin::Txid;
         use std::str::FromStr;
-        let client =
-            utils::build_electrum_client(electrum_server, socks_proxy, validate_domain).ok()?;
+        let client = utils::build_electrum_client(electrum_server, socks_proxy, validate_domain)
+            .inspect_err(|e| log::warn!("build_electrum_client failed: {e}"))
+            .ok()?;
 
         let tx_id = Txid::from_str(txid).ok()?;
         let tx = client.fetch_tx(tx_id).ok()?;

--- a/src/ngwallet.rs
+++ b/src/ngwallet.rs
@@ -398,7 +398,7 @@ impl<P: WalletPersister> NgWallet<P> {
         validate_domain: Option<bool>,
     ) -> Result<SyncResponse> {
         let bdk_client =
-            utils::build_electrum_client(electrum_server, socks_proxy, validate_domain);
+            utils::build_electrum_client(electrum_server, socks_proxy, validate_domain)?;
 
         info!(
             "Syncing wallet with request: {:?}, {:?}",
@@ -419,7 +419,7 @@ impl<P: WalletPersister> NgWallet<P> {
     ) -> Result<FullScanResponse<KeychainKind>> {
         let stop_gap = stop_gap.unwrap_or(DEFAULT_STOP_GAP);
         let client =
-            utils::build_electrum_client(electrum_server, socks_proxy, validate_domain);
+            utils::build_electrum_client(electrum_server, socks_proxy, validate_domain)?;
         let update = client.full_scan(request, stop_gap, BATCH_SIZE, true)?;
         Ok(update)
     }

--- a/src/send.rs
+++ b/src/send.rs
@@ -393,7 +393,7 @@ impl<P: WalletPersister> NgAccount<P> {
         validate_domain: Option<bool>,
     ) -> std::result::Result<Txid, Error> {
         let bdk_client =
-            utils::build_electrum_client(electrum_server, socks_proxy, validate_domain);
+            utils::build_electrum_client(electrum_server, socks_proxy, validate_domain)?;
         let psbt = Psbt::deserialize(&spend.psbt).expect("Failed to deserialize PSBT:");
 
         let transaction = psbt

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,7 +31,7 @@ pub(crate) fn build_electrum_client(
     electrum_server: &str,
     socks_proxy: Option<&str>,
     validate_domain: Option<bool>,
-) -> BdkElectrumClient<Client> {
+) -> Result<BdkElectrumClient<Client>, bdk_electrum::electrum_client::Error> {
     let socks5_config = match socks_proxy {
         Some(socks_proxy) => {
             let socks5_config = Socks5Config::new(socks_proxy);
@@ -47,8 +47,8 @@ pub(crate) fn build_electrum_client(
         .socks5(socks5_config)
         .validate_domain(validate_domain)
         .build();
-    let client = Client::from_config(electrum_server, electrum_config).unwrap();
-    BdkElectrumClient::new(client)
+    let client = Client::from_config(electrum_server, electrum_config)?;
+    Ok(BdkElectrumClient::new(client))
 }
 
 //


### PR DESCRIPTION
## Summary

`build_electrum_client` previously called `Client::from_config(...).unwrap()`, so any failure during raw socket / proxy / SSL setup — including transient DNS resolution failures — would bring down the FRB executor with a `PanicException`. A customer log from a degraded-network sync attempt shows the panic firing exactly there (Linear ENV-2575):

```
PanicException(called Result::unwrap() on an Err value:
  IOError(... failed to lookup address information: nodename nor servname
   provided, or not known))
Backtrace [
  ...
  { fn: "ngwallet::utils::build_electrum_client" },
  ...
]
```

## What changed

- `src/utils.rs` — return type becomes `Result<BdkElectrumClient<Client>, bdk_electrum::electrum_client::Error>`. The `.unwrap()` becomes `?`, and the constructor is wrapped in `Ok(...)`. `BdkElectrumClient::new` is infallible, so `Client::from_config` is the only fallible step.
- Four callers updated to propagate:
  - `src/account.rs:636` — `Option<u64>` returning helper, uses `.ok()?`.
  - `src/ngwallet.rs:401` (`sync`) and `:422` (`scan`) — `anyhow::Result<...>` returning, uses `?` (anyhow auto-converts).
  - `src/send.rs:396` (`broadcast_psbt`) — already returns `Result<Txid, electrum_client::Error>`, uses `?` with zero shim.

No public-API change: `build_electrum_client` is `pub(crate)` and all callsites are within the crate.

Note: `Config::retry(3)` governs RPC-level retries on an already-built client; it does NOT retry `Client::from_config` itself. So this PR doesn't change retry semantics — it just stops a transient failure from killing the host process.

## Out of scope

- `broadcast_psbt` still has `.expect(...)` calls on PSBT decode / extract (`send.rs:397, :401`). Those are PSBT-invariant failures, not electrum-client setup failures, and fixing them cleanly would widen `broadcast_psbt`'s error type beyond `electrum_client::Error`. Tracked separately.
- The fee/network UX consequences of failed sync (e.g. stale fee rates causing the "Cannot calculate fee: available amount too low" symptom seen elsewhere in the same customer report) are unrelated and live in `send.rs:get_max_fee` / Envoy's fee fetch — not here.

## Test plan

- [x] `cargo check --features envoy` passes.
- [ ] Reviewer: confirm `Client::from_config`'s error type matches what `electrum_client 0.23.1` actually returns; the customer's `IOError(...)` panics inside that call.
- [ ] Integration / hardware: drop DNS while a sync is in flight (e.g. airplane mode mid-sync) and verify the app surfaces a sync error instead of crashing.