### PR TITLE
Bump bip322 to 0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bdk_chain"
@@ -111,11 +111,11 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bip322"
-version = "0.0.10"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a160ac75a0c4885f0e69af525351e8d8cab51265fbc28eac15d885a9a0ac99"
+checksum = "ea758a9ba0bb9b2250bd1a3b6e7c9a677d3a51d616a87d74ab7a52ef4a55ca1a"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.0",
  "bitcoin",
  "sha2",
  "snafu",
@@ -967,18 +967,18 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snafu"
-version = "0.8.9"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.9"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sha2 = { version = "0.10.9", optional = true }
 thiserror = "2.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 bitcoin = { version = "0.32", features = ["secp-recovery"], default-features = false }
-bip322 = "0.0.10"
+bip322 = "0.0.11"
 foundation-urtypes = { git = "https://github.com/Foundation-Devices/foundation-rs.git", tag = "0.6.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/src/ngwallet.rs
+++ b/src/ngwallet.rs
@@ -231,7 +231,7 @@ impl<P: WalletPersister> NgWallet<P> {
                         vout,
                         amount,
                         tag: storage
-                            .get_tag(format!("{}{}", &tx_id, vout).as_str())
+                            .get_tag(format!("{}{}", tx_id, vout).as_str())
                             .unwrap_or(None),
                     }
                 })
@@ -253,7 +253,7 @@ impl<P: WalletPersister> NgWallet<P> {
                             &output.script_pubkey,
                             wallet.network(),
                         ),
-                        tag: storage.get_tag(&format!("{}:{}", &tx_id, index)).unwrap(),
+                        tag: storage.get_tag(&format!("{}:{}", tx_id, index)).unwrap(),
                         do_not_spend,
                         keychain: wallet
                             .derivation_of_spk(output.script_pubkey.clone())

--- a/src/psbt/p2sh.rs
+++ b/src/psbt/p2sh.rs
@@ -72,7 +72,7 @@ pub fn validate_output(
         if matches!(purpose, ChildNumber::Hardened { index: 48 }) {
             // For BIP-0048 all paths used to derive an address should be equal.
             let mut are_paths_equal = true;
-            for (_, (_, other_path)) in output.bip32_derivation.iter() {
+            for (_, other_path) in output.bip32_derivation.values() {
                 if other_path != path {
                     are_paths_equal = false;
                     break;

--- a/src/psbt/p2wsh.rs
+++ b/src/psbt/p2wsh.rs
@@ -58,7 +58,7 @@ pub fn validate_output(
     if matches!(purpose, ChildNumber::Hardened { index: 48 }) {
         // For BIP-0048 all paths used to derive an address should be equal.
         let mut are_paths_equal = true;
-        for (_, (_, other_path)) in output.bip32_derivation.iter() {
+        for (_, other_path) in output.bip32_derivation.values() {
             if other_path != path {
                 are_paths_equal = false;
                 break;

--- a/src/sign_message.rs
+++ b/src/sign_message.rs
@@ -98,7 +98,7 @@ pub fn sign_message(
         // Taproot: BIP-137 is undefined for P2TR, so use BIP-322 (Simple
         // variant), which produces a Schnorr signature that verifies against
         // the tweaked output key committed to by the bc1p... address.
-        bip322::sign_simple_encoded(&address.to_string(), message, &private_key.to_wif())
+        bip322::sign_simple_encoded(&address.to_string(), message, &[private_key.to_wif()], None)
             .map_err(|e| SignMessageError::Bip322(e.to_string()))?
     } else {
         // Legacy / SegWit: BIP-137 recoverable ECDSA.


### PR DESCRIPTION
## Summary

- update bip322 from 0.0.10 to 0.0.11
- adapt the single-key Taproot signing call to the 0.0.11 API
- refresh the required transitive lockfile entries
- keep the crate clean under Rust 1.97 Clippy

## Validation

- cargo +1.97.0 fmt --all -- --check
- cargo +1.97.0 clippy --all-targets --all-features -- -D warnings
- cargo +1.97.0 test --verbose --all-targets --all-features (106 passed)