### PR TITLE
Bump foundation-rs to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,12 +358,12 @@ checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
 [[package]]
 name = "foundation-arena"
 version = "0.1.0"
-source = "git+https://github.com/Foundation-Devices/foundation-rs.git?tag=0.6.0#99b00a3d62043391416b5ea438a50e598b1fb1dd"
+source = "git+https://github.com/Foundation-Devices/foundation-rs.git?tag=0.6.1#32c1aece5435b97a3e0816d7d5359a7bd5207a20"
 
 [[package]]
 name = "foundation-urtypes"
 version = "0.5.0"
-source = "git+https://github.com/Foundation-Devices/foundation-rs.git?tag=0.6.0#99b00a3d62043391416b5ea438a50e598b1fb1dd"
+source = "git+https://github.com/Foundation-Devices/foundation-rs.git?tag=0.6.1#32c1aece5435b97a3e0816d7d5359a7bd5207a20"
 dependencies = [
  "faster-hex",
  "foundation-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ thiserror = "2.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 bitcoin = { version = "0.32", features = ["secp-recovery"], default-features = false }
 bip322 = "0.0.11"
-foundation-urtypes = { git = "https://github.com/Foundation-Devices/foundation-rs.git", tag = "0.6.0", default-features = false, features = ["alloc"] }
+foundation-urtypes = { git = "https://github.com/Foundation-Devices/foundation-rs.git", tag = "0.6.1", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 minicbor = { version = "0.24", features = ["alloc"] }
 # Only used inside `#[cfg(test)]` helpers in `src/config.rs` (the
 # crypto-output CBOR encoder/decoder tests); keep it out of the
 # production dep graph.
-foundation-arena = { git = "https://github.com/Foundation-Devices/foundation-rs.git", tag = "0.6.0" }
+foundation-arena = { git = "https://github.com/Foundation-Devices/foundation-rs.git", tag = "0.6.1" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }


### PR DESCRIPTION
﻿## Summary

- bump `foundation-urtypes` from the `foundation-rs` `0.6.0` tag to `0.6.1`
- bump the test-only `foundation-arena` dependency to the same tag
- refresh `Cargo.lock` to resolve both crates from commit `32c1aece`

## Why

`foundation-rs` 0.6.1 includes Foundation-Devices/foundation-rs#56, which fixes master private HD-key decoding so the leading serialization marker is removed without dropping the final secret byte.

Keeping both dependencies on the same tag prevents duplicate source versions and ensures the crypto-output tests exercise the same `foundation-urtypes` dependency used at runtime.
