### PR TITLE
Add legacy P2SH multisig support

### DIFF
--- a/src/bip32.rs
+++ b/src/bip32.rs
@@ -45,35 +45,6 @@ impl NgAccountPath {
             return Ok(None);
         };
 
-        if purpose == 45 {
-            // BIP-0045 is network-independent and uses
-            // m/45'/cosigner_index/change/address rather than the
-            // BIP-0044 coin-type/account layout.
-            let cosigner_index = Self::expect_normal(&mut iter)?;
-            let change = if cosigner_index.is_some() {
-                Self::expect_normal(&mut iter)?
-            } else {
-                None
-            };
-            let address_index = if change.is_some() {
-                Self::expect_normal(&mut iter)?
-            } else {
-                None
-            };
-
-            return Ok(Some(Self {
-                purpose,
-                // BIP-0045 has no coin type or account component. Keep the
-                // public representation anchored to account zero while
-                // network validation is handled specially below.
-                coin_type: 0,
-                account: 0,
-                script_type: None,
-                change,
-                address_index,
-            }));
-        }
-
         if !matches!(purpose, 44 | 48 | 49 | 84 | 86) {
             return Ok(None);
         }
@@ -156,9 +127,6 @@ impl NgAccountPath {
 
     /// Returns true if the derivation path is valid for the given network kind.
     pub fn is_valid_for_network_kind(&self, network: NetworkKind) -> Option<bool> {
-        if self.purpose == 45 {
-            return Some(true);
-        }
         self.to_network_kind().map(|v| network == v)
     }
 
@@ -212,22 +180,6 @@ mod tests {
             .unwrap();
         assert!(account.matches(49, Network::Bitcoin));
         assert_eq!(account.is_change(), Some(true));
-    }
-
-    #[test]
-    fn parse_bip45_receive_and_change() {
-        let receive = NgAccountPath::parse(DerivationPath::from_str("m/45'/7/0/3").unwrap())
-            .unwrap()
-            .unwrap();
-        assert!(receive.matches(45, Network::Bitcoin));
-        assert!(receive.matches(45, Network::Testnet4));
-        assert_eq!(receive.account, 0);
-        assert_eq!(receive.is_change(), Some(false));
-
-        let change = NgAccountPath::parse(DerivationPath::from_str("m/45'/7/1/3").unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(change.is_change(), Some(true));
     }
 
     #[test]

--- a/src/bip32.rs
+++ b/src/bip32.rs
@@ -45,6 +45,35 @@ impl NgAccountPath {
             return Ok(None);
         };
 
+        if purpose == 45 {
+            // BIP-0045 is network-independent and uses
+            // m/45'/cosigner_index/change/address rather than the
+            // BIP-0044 coin-type/account layout.
+            let cosigner_index = Self::expect_normal(&mut iter)?;
+            let change = if cosigner_index.is_some() {
+                Self::expect_normal(&mut iter)?
+            } else {
+                None
+            };
+            let address_index = if change.is_some() {
+                Self::expect_normal(&mut iter)?
+            } else {
+                None
+            };
+
+            return Ok(Some(Self {
+                purpose,
+                // BIP-0045 has no coin type or account component. Keep the
+                // public representation anchored to account zero while
+                // network validation is handled specially below.
+                coin_type: 0,
+                account: 0,
+                script_type: None,
+                change,
+                address_index,
+            }));
+        }
+
         if !matches!(purpose, 44 | 48 | 49 | 84 | 86) {
             return Ok(None);
         }
@@ -127,6 +156,9 @@ impl NgAccountPath {
 
     /// Returns true if the derivation path is valid for the given network kind.
     pub fn is_valid_for_network_kind(&self, network: NetworkKind) -> Option<bool> {
+        if self.purpose == 45 {
+            return Some(true);
+        }
         self.to_network_kind().map(|v| network == v)
     }
 
@@ -180,6 +212,22 @@ mod tests {
             .unwrap();
         assert!(account.matches(49, Network::Bitcoin));
         assert_eq!(account.is_change(), Some(true));
+    }
+
+    #[test]
+    fn parse_bip45_receive_and_change() {
+        let receive = NgAccountPath::parse(DerivationPath::from_str("m/45'/7/0/3").unwrap())
+            .unwrap()
+            .unwrap();
+        assert!(receive.matches(45, Network::Bitcoin));
+        assert!(receive.matches(45, Network::Testnet4));
+        assert_eq!(receive.account, 0);
+        assert_eq!(receive.is_change(), Some(false));
+
+        let change = NgAccountPath::parse(DerivationPath::from_str("m/45'/7/1/3").unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(change.is_change(), Some(true));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,7 +36,8 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 pub const MULTI_SIG_SIGNER_LIMIT: usize = 20;
-pub const ACCEPTED_FORMATS: &[AddressType] = &[AddressType::P2wsh, AddressType::P2ShWsh];
+pub const ACCEPTED_FORMATS: &[AddressType] =
+    &[AddressType::P2sh, AddressType::P2wsh, AddressType::P2ShWsh];
 
 /// Rewrites a SLIP-132 prefixed multisig extended public key to its canonical
 /// `xpub`/`tpub` form so that `bip32::Xpub::from_str` will accept it.
@@ -554,6 +555,7 @@ impl MultiSigDetails {
     /// text-config or string-descriptor formats.
     ///
     /// Accepted shapes (mirroring [`Self::from_descriptor`]):
+    /// - `sh(sortedmulti(M, xpub1, xpub2, ...))` → `P2sh`
     /// - `wsh(sortedmulti(M, xpub1, xpub2, ...))` → `P2wsh`
     /// - `sh(wsh(sortedmulti(M, xpub1, xpub2, ...)))` → `P2ShWsh`
     ///
@@ -575,6 +577,7 @@ impl MultiSigDetails {
                 ),
             },
             Terminal::ScriptHash(outer) => match &**outer {
+                Terminal::SortedMultisig(mk) => (AddressType::P2sh, mk),
                 Terminal::WitnessScriptHash(inner) => match &**inner {
                     Terminal::SortedMultisig(mk) => (AddressType::P2ShWsh, mk),
                     Terminal::Multisig(_) => anyhow::bail!(
@@ -585,11 +588,11 @@ impl MultiSigDetails {
                     ),
                 },
                 _ => anyhow::bail!(
-                    "crypto-output sh() must wrap wsh(sortedmulti), other scripts are not accepted"
+                    "crypto-output sh() must wrap sortedmulti or wsh(sortedmulti), other scripts are not accepted"
                 ),
             },
             _ => anyhow::bail!(
-                "crypto-output descriptors must be wsh(sortedmulti) or sh(wsh(sortedmulti))"
+                "crypto-output descriptors must be sh(sortedmulti), wsh(sortedmulti), or sh(wsh(sortedmulti))"
             ),
         };
 
@@ -631,6 +634,7 @@ impl MultiSigDetails {
 
         match descriptor {
             BdkDescriptor::Sh(desc) => match desc.into_inner() {
+                ShInner::SortedMulti(ms) => Self::from_sorted_multi(AddressType::P2sh, ms),
                 ShInner::Wsh(d) => match d.into_inner() {
                     WshInner::SortedMulti(ms) => Self::from_sorted_multi(AddressType::P2ShWsh, ms),
                     _ => anyhow::bail!(
@@ -638,7 +642,7 @@ impl MultiSigDetails {
                     ),
                 },
                 _ => anyhow::bail!(
-                    "Multisig descriptors starting with Sh() should contain Wsh(SortedMulti()), other scripts are not currently accepted"
+                    "Multisig descriptors starting with Sh() should contain SortedMulti() or Wsh(SortedMulti()), other scripts are not currently accepted"
                 ),
             },
             BdkDescriptor::Wsh(desc) => match desc.into_inner() {
@@ -695,6 +699,10 @@ impl MultiSigDetails {
             .collect::<Vec<DescriptorPublicKey>>();
 
         let descriptor = match self.format {
+            AddressType::P2sh => BdkDescriptor::<DescriptorPublicKey>::new_sh_sortedmulti(
+                self.policy_threshold,
+                signers,
+            )?,
             AddressType::P2ShWsh => BdkDescriptor::<DescriptorPublicKey>::new_sh_wsh_sortedmulti(
                 self.policy_threshold,
                 signers,
@@ -746,6 +754,7 @@ impl MultiSigDetails {
 
     pub fn get_bip(&self) -> Result<String, anyhow::Error> {
         Ok(match self.format {
+            AddressType::P2sh => String::from("45"),
             AddressType::P2ShWsh => String::from("48_1"),
             AddressType::P2wsh => String::from("48_2"),
             other => anyhow::bail!(
@@ -1883,6 +1892,42 @@ Derivation: m/48'/1'/0'/2'
                 .all(|signer| signer.pubkey.starts_with("xpub"))
         );
         assert!(MultiSigDetails::from_descriptor(&format!("{body}#deadbeef")).is_err());
+    }
+
+    #[test]
+    fn multisig_from_legacy_p2sh_descriptor_round_trips() {
+        let descriptor = "sh(sortedmulti(2,[71C8BD85/45h]xpub6ESpvmZa75rCQWKik2KoCZrjTi6xhSubZKJ25rbtgZRk2g9tZTJqubhaGD3dJeqruw9KMCaanoEfJ1PVtBXiwTuuqLVwk9ucqkRv1sKWiEC/<0;1>/*,[AB88DE89/45h]xpub6EPJuK8Ejz82nKc7PsRgcYqdcQH9G1ZikCTasr9i79CbXxMMiPfxEyA14S6HPTHufmcQR7x8t5L3BP9tRfm9EBRBPic2xV892j9z4ePESae/<0;1>/*,[A9F9964A/45h]xpub6FQY5W8WygMVYY2nTP188jFHNdZfH2t9qtcS8SPpFatUGiciqUsGZpNvEa1oABEyeAsrUL2XSnvuRUdrhf5LcMXcjhrUFBcneBYYZzky3Mc/<0;1>/*))";
+
+        let (multisig, name) = MultiSigDetails::from_descriptor(descriptor).unwrap();
+        assert_eq!(multisig.format, AddressType::P2sh);
+        assert_eq!(name, "Multisig-2-of-3-Main");
+
+        let secp = Secp256k1::new();
+        let receive_descriptor = multisig
+            .to_descriptor(KeychainKind::External, &secp, None)
+            .unwrap()
+            .0;
+        let change_descriptor = multisig
+            .to_descriptor(KeychainKind::Internal, &secp, None)
+            .unwrap()
+            .0;
+
+        assert_eq!(
+            receive_descriptor.desc_type(),
+            bdk_wallet::miniscript::descriptor::DescriptorType::ShSortedMulti
+        );
+        assert_eq!(
+            change_descriptor.desc_type(),
+            bdk_wallet::miniscript::descriptor::DescriptorType::ShSortedMulti
+        );
+
+        let (reloaded, _) =
+            MultiSigDetails::from_descriptor(&receive_descriptor.to_string()).unwrap();
+        assert_eq!(reloaded, multisig);
+
+        let descriptors = multisig.get_descriptors(&secp, None).unwrap();
+        assert_eq!(descriptors[0].bip, "45");
+        assert_eq!(descriptors[0].export_addr_hint, AddressType::P2sh);
     }
 
     // Regression test for SFT-6907: BlueWallet emits P2WSH multisig exports

--- a/src/config.rs
+++ b/src/config.rs
@@ -538,7 +538,7 @@ impl MultiSigDetails {
                         desc_xpub.xkey,
                         fingerprint,
                         origin_path,
-                        common_path.as_ref(),
+                        common_path,
                     )
                 }
                 other => anyhow::bail!("Descriptor has {other:?} rather than xpub"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 pub const MULTI_SIG_SIGNER_LIMIT: usize = 20;
+pub const LEGACY_P2SH_SIGNER_LIMIT: usize = 15;
 pub const ACCEPTED_FORMATS: &[AddressType] =
     &[AddressType::P2sh, AddressType::P2wsh, AddressType::P2ShWsh];
 
@@ -280,6 +281,13 @@ impl MultiSigDetails {
                 MULTI_SIG_SIGNER_LIMIT
             );
         }
+        if format == AddressType::P2sh && policy_total_keys > LEGACY_P2SH_SIGNER_LIMIT {
+            anyhow::bail!(
+                "legacy P2SH multisig has {} signers, limit is {}",
+                policy_total_keys,
+                LEGACY_P2SH_SIGNER_LIMIT
+            );
+        }
 
         if signers.len() < 2 {
             anyhow::bail!("Multisigs require at least 2 total signers (N)");
@@ -455,19 +463,40 @@ impl MultiSigDetails {
             .iter()
             .map(|pk| match pk {
                 DescriptorPublicKey::XPub(desc_xpub) => {
-                    let (fingerprint, derivation_path) = match &desc_xpub.origin {
-                        Some((f, d)) => (*f, d.clone()),
+                    let (fingerprint, origin_path) = match &desc_xpub.origin {
+                        Some((fingerprint, path)) => (*fingerprint, path.clone()),
                         None => anyhow::bail!(
                             "Descriptor xpub {} doesn't contain origin info",
                             desc_xpub.xkey
                         ),
                     };
-                    let xpub = desc_xpub.xkey;
-                    Ok(MultiSigSigner::new(&derivation_path, &fingerprint, &xpub))
+
+                    if format != AddressType::P2sh {
+                        return Ok(MultiSigSigner::new(
+                            &origin_path,
+                            &fingerprint,
+                            &desc_xpub.xkey,
+                        ));
+                    }
+
+                    let mut account_suffix = desc_xpub.derivation_path.as_ref().to_vec();
+                    match account_suffix.pop() {
+                        Some(ChildNumber::Normal { index: 0 | 1 }) => {}
+                        _ => anyhow::bail!(
+                            "Descriptor xpub {} must end in a receive/change branch before its wildcard",
+                            desc_xpub.xkey
+                        ),
+                    }
+                    Self::signer_from_xpub(
+                        desc_xpub.xkey,
+                        fingerprint,
+                        origin_path,
+                        &account_suffix,
+                    )
                 }
                 DescriptorPublicKey::MultiXPub(desc_xpub) => {
                     let (fingerprint, origin_path) = match &desc_xpub.origin {
-                        Some((f, d)) => (*f, d.clone()),
+                        Some((fingerprint, path)) => (*fingerprint, path.clone()),
                         None => anyhow::bail!(
                             "Descriptor xpub {} doesn't contain origin info",
                             desc_xpub.xkey
@@ -487,8 +516,7 @@ impl MultiSigDetails {
                             .take_while(|(left, right)| left == right)
                             .count()
                     });
-                    let common_path =
-                        DerivationPath::from(first_path.as_ref()[..common_len].to_vec());
+                    let common_path = &first_path.as_ref()[..common_len];
 
                     let keychains = paths
                         .iter()
@@ -1896,7 +1924,11 @@ Derivation: m/48'/1'/0'/2'
 
     #[test]
     fn multisig_from_legacy_p2sh_descriptor_round_trips() {
-        let descriptor = "sh(sortedmulti(2,[71C8BD85/45h]xpub6ESpvmZa75rCQWKik2KoCZrjTi6xhSubZKJ25rbtgZRk2g9tZTJqubhaGD3dJeqruw9KMCaanoEfJ1PVtBXiwTuuqLVwk9ucqkRv1sKWiEC/<0;1>/*,[AB88DE89/45h]xpub6EPJuK8Ejz82nKc7PsRgcYqdcQH9G1ZikCTasr9i79CbXxMMiPfxEyA14S6HPTHufmcQR7x8t5L3BP9tRfm9EBRBPic2xV892j9z4ePESae/<0;1>/*,[A9F9964A/45h]xpub6FQY5W8WygMVYY2nTP188jFHNdZfH2t9qtcS8SPpFatUGiciqUsGZpNvEa1oABEyeAsrUL2XSnvuRUdrhf5LcMXcjhrUFBcneBYYZzky3Mc/<0;1>/*))";
+        let descriptor = "sh(sortedmulti(2,[71C8BD85/45h]xpub6ESpvmZa75rCQWKik2KoCZrjTi6xhSubZKJ25rbtgZRk2g9tZTJqubhaGD3dJeqruw9KMCaanoEfJ1PVtBXiwTuuqLVwk9ucqkRv1sKWiEC/0/<0;1>/*,[AB88DE89/45h]xpub6EPJuK8Ejz82nKc7PsRgcYqdcQH9G1ZikCTasr9i79CbXxMMiPfxEyA14S6HPTHufmcQR7x8t5L3BP9tRfm9EBRBPic2xV892j9z4ePESae/0/<0;1>/*,[A9F9964A/45h]xpub6FQY5W8WygMVYY2nTP188jFHNdZfH2t9qtcS8SPpFatUGiciqUsGZpNvEa1oABEyeAsrUL2XSnvuRUdrhf5LcMXcjhrUFBcneBYYZzky3Mc/0/<0;1>/*))";
+        let expected_descriptors = BdkDescriptor::<DescriptorPublicKey>::from_str(descriptor)
+            .unwrap()
+            .into_single_descriptors()
+            .unwrap();
 
         let (multisig, name) = MultiSigDetails::from_descriptor(descriptor).unwrap();
         assert_eq!(multisig.format, AddressType::P2sh);
@@ -1920,6 +1952,26 @@ Derivation: m/48'/1'/0'/2'
             change_descriptor.desc_type(),
             bdk_wallet::miniscript::descriptor::DescriptorType::ShSortedMulti
         );
+        assert_eq!(
+            receive_descriptor
+                .derived_descriptor(&secp, 7)
+                .unwrap()
+                .script_pubkey(),
+            expected_descriptors[0]
+                .derived_descriptor(&secp, 7)
+                .unwrap()
+                .script_pubkey()
+        );
+        assert_eq!(
+            change_descriptor
+                .derived_descriptor(&secp, 7)
+                .unwrap()
+                .script_pubkey(),
+            expected_descriptors[1]
+                .derived_descriptor(&secp, 7)
+                .unwrap()
+                .script_pubkey()
+        );
 
         let (reloaded, _) =
             MultiSigDetails::from_descriptor(&receive_descriptor.to_string()).unwrap();
@@ -1928,6 +1980,22 @@ Derivation: m/48'/1'/0'/2'
         let descriptors = multisig.get_descriptors(&secp, None).unwrap();
         assert_eq!(descriptors[0].bip, "45");
         assert_eq!(descriptors[0].export_addr_hint, AddressType::P2sh);
+    }
+
+    #[test]
+    fn legacy_p2sh_rejects_more_than_fifteen_signers() {
+        let secp = Secp256k1::new();
+        let derivation = DerivationPath::from_str("m/45'").unwrap();
+        let signers = (1u8..=16)
+            .map(|seed_byte| {
+                let master = Xpriv::new_master(Network::Bitcoin, &[seed_byte; 32]).unwrap();
+                let fingerprint = master.fingerprint(&secp);
+                let xpub = Xpub::from_priv(&secp, &master.derive_priv(&secp, &derivation).unwrap());
+                MultiSigSigner::new(&derivation, &fingerprint, &xpub)
+            })
+            .collect::<Vec<_>>();
+
+        assert!(MultiSigDetails::new(2, 16, AddressType::P2sh, None, signers).is_err());
     }
 
     // Regression test for SFT-6907: BlueWallet emits P2WSH multisig exports

--- a/src/psbt.rs
+++ b/src/psbt.rs
@@ -7,7 +7,7 @@ mod p2wpkh;
 mod p2wsh;
 
 use crate::bip32::{NgAccountPath, ParsePathError};
-use crate::config::MultiSigDetails;
+use crate::config::{AddressType, MultiSigDetails};
 use bdk_wallet::KeychainKind;
 use bdk_wallet::bitcoin::bip32;
 use bdk_wallet::bitcoin::bip32::{
@@ -693,16 +693,35 @@ where
                         return Err(Error::MissingInputFundingUtxo { index: i });
                     }
 
-                    let required_signers = multisig::disassemble_sorted(redeem_script)
-                        .map_err(|_| Error::InvalidMultisigScript { index: i })?;
-                    let multisig_descriptors = p2sh::legacy_multisig_descriptor(
-                        required_signers,
-                        &psbt.xpub,
-                        &input.bip32_derivation,
-                    )?;
+                    match registered_multisig {
+                        Some(multisig) => {
+                            validate_registered_multisig_input(
+                                secp,
+                                multisig,
+                                fingerprint,
+                                &input.bip32_derivation,
+                                &funding_utxo.script_pubkey,
+                                i,
+                            )?;
+                            insert_registered_multisig_descriptors(
+                                secp,
+                                multisig,
+                                &mut descriptors,
+                            )?;
+                        }
+                        None => {
+                            let required_signers = multisig::disassemble_sorted(redeem_script)
+                                .map_err(|_| Error::InvalidMultisigScript { index: i })?;
+                            let multisig_descriptors = p2sh::legacy_multisig_descriptor(
+                                required_signers,
+                                &psbt.xpub,
+                                &input.bip32_derivation,
+                            )?;
 
-                    for descriptor in multisig_descriptors {
-                        descriptors.insert(descriptor);
+                            for descriptor in multisig_descriptors {
+                                descriptors.insert(descriptor);
+                            }
+                        }
                     }
                 } else {
                     // TODO: Change to UnknownInputScript

--- a/src/psbt.rs
+++ b/src/psbt.rs
@@ -686,6 +686,24 @@ where
                     } else {
                         return Err(Error::MissingWitnessScript { index: i });
                     }
+                } else if redeem_script.is_multisig() {
+                    // Legacy inputs must include the full previous transaction;
+                    // witness_utxo alone is not sufficient for pre-SegWit spends.
+                    if input.non_witness_utxo.is_none() {
+                        return Err(Error::MissingInputFundingUtxo { index: i });
+                    }
+
+                    let required_signers = multisig::disassemble_sorted(redeem_script)
+                        .map_err(|_| Error::InvalidMultisigScript { index: i })?;
+                    let multisig_descriptors = p2sh::legacy_multisig_descriptor(
+                        required_signers,
+                        &psbt.xpub,
+                        &input.bip32_derivation,
+                    )?;
+
+                    for descriptor in multisig_descriptors {
+                        descriptors.insert(descriptor);
+                    }
                 } else {
                     // TODO: Change to UnknownInputScript
                     return Err(Error::UnknownOutputScript { index: i });

--- a/src/psbt.rs
+++ b/src/psbt.rs
@@ -7,7 +7,7 @@ mod p2wpkh;
 mod p2wsh;
 
 use crate::bip32::{NgAccountPath, ParsePathError};
-use crate::config::{AddressType, MultiSigDetails};
+use crate::config::MultiSigDetails;
 use bdk_wallet::KeychainKind;
 use bdk_wallet::bitcoin::bip32;
 use bdk_wallet::bitcoin::bip32::{
@@ -1207,4 +1207,20 @@ pub(crate) fn registered_multisig_output_kind<C: Signing + Verification>(
             OutputKind::Transfer { address, account }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn bip45_path_does_not_infer_a_network() {
+        let source = (
+            Fingerprint::from([1, 2, 3, 4]),
+            DerivationPath::from_str("m/45'/2/0/7").unwrap(),
+        );
+
+        assert_eq!(validate_key_source_network(None, &source).unwrap(), None);
+    }
 }

--- a/src/psbt/multisig.rs
+++ b/src/psbt/multisig.rs
@@ -21,6 +21,8 @@ pub enum Error {
     MalformedScript,
     #[error("public keys are not strictly sorted")]
     PublicKeysNotSorted,
+    #[error("public keys must use compressed encoding")]
+    UncompressedPublicKey,
     #[error("invalid total public keys length")]
     InvalidTotalPublicKeysLength,
     #[error("unexpected end of script")]
@@ -40,6 +42,9 @@ pub fn disassemble(script: &Script) -> Result<u8, Error> {
 /// ordering, matching a `sortedmulti` descriptor.
 pub fn disassemble_sorted(script: &Script) -> Result<u8, Error> {
     let (required_signers, public_keys) = disassemble_inner(script)?;
+    if public_keys.iter().any(|key| !key.compressed) {
+        return Err(Error::UncompressedPublicKey);
+    }
     if !public_keys
         .windows(2)
         .all(|keys| keys[0].inner.serialize() < keys[1].inner.serialize())
@@ -125,6 +130,28 @@ mod tests {
     use bdk_wallet::bitcoin::script::Builder;
     use bdk_wallet::bitcoin::secp256k1::{Secp256k1, SecretKey};
 
+    fn sorted_keys() -> [PublicKey; 2] {
+        let secp = Secp256k1::new();
+        let mut keys = [1u8, 2].map(|byte| {
+            PublicKey::new(bdk_wallet::bitcoin::secp256k1::PublicKey::from_secret_key(
+                &secp,
+                &SecretKey::from_slice(&[byte; 32]).unwrap(),
+            ))
+        });
+        keys.sort_by_key(|key| key.inner.serialize());
+        keys
+    }
+
+    fn multisig_script(keys: &[PublicKey; 2]) -> ScriptBuf {
+        Builder::new()
+            .push_int(2)
+            .push_key(&keys[0])
+            .push_key(&keys[1])
+            .push_int(2)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script()
+    }
+
     #[test]
     fn empty_script_does_not_panic() {
         let script = ScriptBuf::new();
@@ -155,30 +182,28 @@ mod tests {
 
     #[test]
     fn sorted_disassembly_rejects_unsorted_keys() {
-        let secp = Secp256k1::new();
-        let mut keys = [
-            PublicKey::new(bdk_wallet::bitcoin::secp256k1::PublicKey::from_secret_key(
-                &secp,
-                &SecretKey::from_slice(&[1u8; 32]).unwrap(),
-            )),
-            PublicKey::new(bdk_wallet::bitcoin::secp256k1::PublicKey::from_secret_key(
-                &secp,
-                &SecretKey::from_slice(&[2u8; 32]).unwrap(),
-            )),
-        ];
-        keys.sort_by_key(|key| key.inner.serialize());
+        let mut keys = sorted_keys();
         keys.reverse();
-        let script = Builder::new()
-            .push_int(2)
-            .push_key(&keys[0])
-            .push_key(&keys[1])
-            .push_int(2)
-            .push_opcode(OP_CHECKMULTISIG)
-            .into_script();
 
         assert!(matches!(
-            disassemble_sorted(&script),
+            disassemble_sorted(&multisig_script(&keys)),
             Err(Error::PublicKeysNotSorted)
         ));
+    }
+
+    #[test]
+    fn sorted_disassembly_accepts_sorted_compressed_keys() {
+        assert_eq!(disassemble_sorted(&multisig_script(&sorted_keys())), Ok(2));
+    }
+
+    #[test]
+    fn sorted_disassembly_rejects_uncompressed_keys() {
+        let keys = sorted_keys();
+        let keys = [keys[0], PublicKey::new_uncompressed(keys[1].inner)];
+
+        assert_eq!(
+            disassemble_sorted(&multisig_script(&keys)),
+            Err(Error::UncompressedPublicKey)
+        );
     }
 }

--- a/src/psbt/multisig.rs
+++ b/src/psbt/multisig.rs
@@ -19,6 +19,8 @@ pub enum Error {
     MalformedPublicKey,
     #[error("malformed script")]
     MalformedScript,
+    #[error("public keys are not strictly sorted")]
+    PublicKeysNotSorted,
     #[error("invalid total public keys length")]
     InvalidTotalPublicKeysLength,
     #[error("unexpected end of script")]
@@ -31,21 +33,39 @@ pub enum Error {
 ///
 /// This returns the number of signers required on success.
 pub fn disassemble(script: &Script) -> Result<u8, Error> {
+    disassemble_inner(script).map(|(required_signers, _)| required_signers)
+}
+
+/// Disassemble a multisig script and require BIP-67 lexicographic public-key
+/// ordering, matching a `sortedmulti` descriptor.
+pub fn disassemble_sorted(script: &Script) -> Result<u8, Error> {
+    let (required_signers, public_keys) = disassemble_inner(script)?;
+    if !public_keys
+        .windows(2)
+        .all(|keys| keys[0].inner.serialize() < keys[1].inner.serialize())
+    {
+        return Err(Error::PublicKeysNotSorted);
+    }
+
+    Ok(required_signers)
+}
+
+fn disassemble_inner(script: &Script) -> Result<(u8, Vec<PublicKey>), Error> {
     let mut instructions = script.instructions_minimal().peekable();
 
     let m = parse_pushnum(&mut instructions).ok_or(Error::UnexpectedEof)??;
 
-    let mut public_keys = 0;
+    let mut public_keys = Vec::new();
     loop {
         match parse_public_key(&mut instructions).ok_or(Error::UnexpectedEof)? {
-            Ok(_) => public_keys += 1,
+            Ok(public_key) => public_keys.push(public_key),
             Err(Error::ExpectedPublicKey) => break,
             Err(e) => return Err(e),
         }
     }
 
     let n = parse_pushnum(&mut instructions).ok_or(Error::UnexpectedEof)??;
-    if usize::from(n) != public_keys {
+    if usize::from(n) != public_keys.len() {
         return Err(Error::InvalidTotalPublicKeysLength);
     }
 
@@ -54,7 +74,7 @@ pub fn disassemble(script: &Script) -> Result<u8, Error> {
     if instructions.next().is_some() {
         Err(Error::ExpectedEof)
     } else {
-        Ok(m)
+        Ok((m, public_keys))
     }
 }
 
@@ -103,6 +123,7 @@ mod tests {
     use bdk_wallet::bitcoin::ScriptBuf;
     use bdk_wallet::bitcoin::opcodes::all::OP_RETURN;
     use bdk_wallet::bitcoin::script::Builder;
+    use bdk_wallet::bitcoin::secp256k1::{Secp256k1, SecretKey};
 
     #[test]
     fn empty_script_does_not_panic() {
@@ -130,5 +151,34 @@ mod tests {
         // Just OP_PUSHNUM_2 with nothing after it.
         let script = ScriptBuf::from_bytes(vec![0x52]);
         assert!(matches!(disassemble(&script), Err(Error::UnexpectedEof)));
+    }
+
+    #[test]
+    fn sorted_disassembly_rejects_unsorted_keys() {
+        let secp = Secp256k1::new();
+        let mut keys = [
+            PublicKey::new(bdk_wallet::bitcoin::secp256k1::PublicKey::from_secret_key(
+                &secp,
+                &SecretKey::from_slice(&[1u8; 32]).unwrap(),
+            )),
+            PublicKey::new(bdk_wallet::bitcoin::secp256k1::PublicKey::from_secret_key(
+                &secp,
+                &SecretKey::from_slice(&[2u8; 32]).unwrap(),
+            )),
+        ];
+        keys.sort_by_key(|key| key.inner.serialize());
+        keys.reverse();
+        let script = Builder::new()
+            .push_int(2)
+            .push_key(&keys[0])
+            .push_key(&keys[1])
+            .push_int(2)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script();
+
+        assert!(matches!(
+            disassemble_sorted(&script),
+            Err(Error::PublicKeysNotSorted)
+        ));
     }
 }

--- a/src/psbt/p2sh.rs
+++ b/src/psbt/p2sh.rs
@@ -1,10 +1,9 @@
 use crate::bip32::NgAccountPath;
 use crate::config::MultiSigDetails;
 use crate::psbt::{
-    Error, OutputKind, PsbtOutput, derive_account_xpub, derive_full_descriptor_pubkey,
-    multisig, registered_multisig_output_kind, sort_keys,
+    Error, OutputKind, PsbtOutput, derive_account_xpub, derive_full_descriptor_pubkey, multisig,
+    registered_multisig_output_kind, sort_keys,
 };
-use bdk_wallet::KeychainKind;
 use bdk_wallet::bitcoin::bip32::{ChildNumber, DerivationPath, KeySource, Xpriv, Xpub};
 use bdk_wallet::bitcoin::psbt;
 use bdk_wallet::bitcoin::secp256k1::{PublicKey, Secp256k1, Signing, Verification};
@@ -242,34 +241,53 @@ fn multisig_descriptor_keys(
         .map(|(_, (subpath_fingerprint, subpath))| {
             global_xpubs
                 .iter()
-                .find(|(_, (global_fingerprint, global_path))| {
+                .filter(|(_, (global_fingerprint, global_path))| {
                     subpath_fingerprint == global_fingerprint
                         && subpath.as_ref().starts_with(global_path.as_ref())
                 })
+                .max_by_key(|(_, (_, global_path))| global_path.as_ref().len())
+                .map(|(xpub, source)| (xpub, source, subpath))
                 .ok_or_else(|| Error::MissingGlobalXpub(subpath.clone()))
         });
 
     let mut external_keys = Vec::new();
     let mut internal_keys = Vec::new();
     for maybe_xpub in xpubs {
-        let (xpub, source) = maybe_xpub?;
+        let (xpub, source, subpath) = maybe_xpub?;
+        let relative_path = subpath
+            .as_ref()
+            .strip_prefix(source.1.as_ref())
+            .ok_or(Error::InvalidMultisigDescriptor)?;
+        if relative_path.len() < 2
+            || !matches!(
+                relative_path[relative_path.len() - 2],
+                ChildNumber::Normal { index: 0 | 1 }
+            )
+            || !matches!(
+                relative_path[relative_path.len() - 1],
+                ChildNumber::Normal { .. }
+            )
+        {
+            return Err(Error::InvalidMultisigDescriptor);
+        }
+        let account_suffix = &relative_path[..relative_path.len() - 2];
+        let descriptor_key = |branch| {
+            DescriptorPublicKey::XPub(DescriptorXKey {
+                origin: Some(source.clone()),
+                xkey: *xpub,
+                derivation_path: DerivationPath::from(
+                    account_suffix
+                        .iter()
+                        .copied()
+                        .chain([ChildNumber::Normal { index: branch }])
+                        .collect::<Vec<_>>(),
+                ),
+                wildcard: Wildcard::Unhardened,
+            })
+        };
 
-        let external_key = DescriptorPublicKey::XPub(DescriptorXKey {
-            origin: Some(source.clone()),
-            xkey: *xpub,
-            derivation_path: DerivationPath::from(vec![ChildNumber::Normal { index: 0 }]),
-            wildcard: Wildcard::Unhardened,
-        });
-
-        let internal_key = DescriptorPublicKey::XPub(DescriptorXKey {
-            origin: Some(source.clone()),
-            xkey: *xpub,
-            derivation_path: DerivationPath::from(vec![ChildNumber::Normal { index: 1 }]),
-            wildcard: Wildcard::Unhardened,
-        });
-
-        external_keys.push(external_key);
-        internal_keys.push(internal_key);
+        external_keys.push(descriptor_key(0));
+        internal_keys.push(descriptor_key(1));
     }
 
     sort_keys(&mut external_keys);
@@ -282,6 +300,7 @@ fn multisig_descriptor_keys(
 mod tests {
     use super::*;
     use crate::config::{AddressType, MultiSigSigner};
+    use bdk_wallet::KeychainKind;
     use bdk_wallet::bitcoin::hashes::{Hash, sha256};
     use bdk_wallet::bitcoin::opcodes::all::{OP_EQUAL, OP_HASH160, OP_PUSHBYTES_0, OP_RETURN};
     use bdk_wallet::bitcoin::{Amount, Script, ScriptBuf, WScriptHash};
@@ -376,6 +395,47 @@ mod tests {
         output.bip32_derivation = derivations;
 
         (output, txout, multisig)
+    }
+
+    #[test]
+    fn legacy_descriptor_preserves_bip45_cosigner_paths() {
+        let secp = Secp256k1::new();
+        let purpose_path = DerivationPath::from(vec![ChildNumber::Hardened { index: 45 }]);
+        let mut global_xpubs = BTreeMap::new();
+        let mut derivations = BTreeMap::new();
+
+        for (seed, cosigner_index) in [(1u8, 2u32), (2, 7)] {
+            let master = Xpriv::new_master(Network::Bitcoin, &[seed; 32]).unwrap();
+            let fingerprint = master.fingerprint(&secp);
+            let purpose_xpriv = master.derive_priv(&secp, &purpose_path).unwrap();
+            global_xpubs.insert(
+                Xpub::from_priv(&secp, &purpose_xpriv),
+                (fingerprint, purpose_path.clone()),
+            );
+
+            let address_path = DerivationPath::from(vec![
+                ChildNumber::Hardened { index: 45 },
+                ChildNumber::Normal {
+                    index: cosigner_index,
+                },
+                ChildNumber::Normal { index: 0 },
+                ChildNumber::Normal { index: 3 },
+            ]);
+            let public_key =
+                Xpub::from_priv(&secp, &master.derive_priv(&secp, &address_path).unwrap())
+                    .public_key;
+            derivations.insert(public_key, (fingerprint, address_path));
+        }
+
+        let [external, internal] =
+            legacy_multisig_descriptor(2, &global_xpubs, &derivations).unwrap();
+        let external = external.to_string();
+        let internal = internal.to_string();
+
+        for cosigner_index in [2, 7] {
+            assert!(external.contains(&format!("/{cosigner_index}/0/*")));
+            assert!(internal.contains(&format!("/{cosigner_index}/1/*")));
+        }
     }
 
     /// A nested P2SH-P2WSH with a malformed witness_script must not panic.

--- a/src/psbt/p2sh.rs
+++ b/src/psbt/p2sh.rs
@@ -2,8 +2,9 @@ use crate::bip32::NgAccountPath;
 use crate::config::MultiSigDetails;
 use crate::psbt::{
     Error, OutputKind, PsbtOutput, derive_account_xpub, derive_full_descriptor_pubkey,
-    registered_multisig_output_kind, sort_keys,
+    multisig, registered_multisig_output_kind, sort_keys,
 };
+use bdk_wallet::KeychainKind;
 use bdk_wallet::bitcoin::bip32::{ChildNumber, DerivationPath, KeySource, Xpriv, Xpub};
 use bdk_wallet::bitcoin::psbt;
 use bdk_wallet::bitcoin::secp256k1::{PublicKey, Secp256k1, Signing, Verification};
@@ -76,10 +77,53 @@ pub fn validate_output<C: Signing + Verification>(
             amount: txout.value,
             kind,
         })
+    } else if redeem_script.is_multisig() {
+        validate_legacy_multisig_output(
+            secp,
+            output,
+            txout,
+            redeem_script,
+            network,
+            index,
+            registered_multisig,
+        )
     } else {
-        // TODO: Legacy P2SH (e.g. BIP45).
-        Err(Error::Unimplemented)
+        Err(Error::InvalidRedeemScript { index })
     }
+}
+
+fn validate_legacy_multisig_output<C: Signing + Verification>(
+    secp: &Secp256k1<C>,
+    output: &psbt::Output,
+    txout: &TxOut,
+    redeem_script: &bdk_wallet::bitcoin::Script,
+    network: Network,
+    index: usize,
+    registered_multisig: Option<&MultiSigDetails>,
+) -> Result<PsbtOutput, Error> {
+    multisig::disassemble_sorted(redeem_script)
+        .map_err(|_| Error::InvalidMultisigScript { index })?;
+    let address =
+        Address::p2sh(redeem_script, network).map_err(|_| Error::InvalidRedeemScript { index })?;
+    if !address.matches_script_pubkey(&txout.script_pubkey) {
+        return Err(Error::FraudulentOutput { index });
+    }
+
+    let kind = registered_multisig
+        .and_then(|multisig| {
+            registered_multisig_output_kind(
+                secp,
+                multisig,
+                &output.bip32_derivation,
+                &txout.script_pubkey,
+                address.clone(),
+            )
+        })
+        .unwrap_or(OutputKind::External(address));
+    Ok(PsbtOutput {
+        amount: txout.value,
+        kind,
+    })
 }
 
 fn validate_p2wpkh_nested_in_p2sh_output(
@@ -157,6 +201,41 @@ pub fn wsh_multisig_descriptor(
     global_xpubs: &BTreeMap<Xpub, KeySource>,
     bip32_derivations: &BTreeMap<PublicKey, KeySource>,
 ) -> Result<[ExtendedDescriptor; 2], Error> {
+    let (external_keys, internal_keys) = multisig_descriptor_keys(global_xpubs, bip32_derivations)?;
+
+    let external_descriptor =
+        ExtendedDescriptor::new_sh_wsh_sortedmulti(usize::from(required_signers), external_keys)
+            .map_err(|_| Error::InvalidMultisigDescriptor)?;
+    let internal_descriptor =
+        ExtendedDescriptor::new_sh_wsh_sortedmulti(usize::from(required_signers), internal_keys)
+            .map_err(|_| Error::InvalidMultisigDescriptor)?;
+
+    Ok([external_descriptor, internal_descriptor])
+}
+
+/// Returns the external and internal descriptors for a legacy P2SH
+/// `sortedmulti` account.
+pub fn legacy_multisig_descriptor(
+    required_signers: u8,
+    global_xpubs: &BTreeMap<Xpub, KeySource>,
+    bip32_derivations: &BTreeMap<PublicKey, KeySource>,
+) -> Result<[ExtendedDescriptor; 2], Error> {
+    let (external_keys, internal_keys) = multisig_descriptor_keys(global_xpubs, bip32_derivations)?;
+
+    let external_descriptor =
+        ExtendedDescriptor::new_sh_sortedmulti(usize::from(required_signers), external_keys)
+            .map_err(|_| Error::InvalidMultisigDescriptor)?;
+    let internal_descriptor =
+        ExtendedDescriptor::new_sh_sortedmulti(usize::from(required_signers), internal_keys)
+            .map_err(|_| Error::InvalidMultisigDescriptor)?;
+
+    Ok([external_descriptor, internal_descriptor])
+}
+
+fn multisig_descriptor_keys(
+    global_xpubs: &BTreeMap<Xpub, KeySource>,
+    bip32_derivations: &BTreeMap<PublicKey, KeySource>,
+) -> Result<(Vec<DescriptorPublicKey>, Vec<DescriptorPublicKey>), Error> {
     // Find the account Xpubs in the global Xpub map of the PSBT.
     let xpubs = bip32_derivations
         .iter()
@@ -196,19 +275,13 @@ pub fn wsh_multisig_descriptor(
     sort_keys(&mut external_keys);
     sort_keys(&mut internal_keys);
 
-    let external_descriptor =
-        ExtendedDescriptor::new_sh_wsh_sortedmulti(usize::from(required_signers), external_keys)
-            .map_err(|_| Error::InvalidMultisigDescriptor)?;
-    let internal_descriptor =
-        ExtendedDescriptor::new_sh_wsh_sortedmulti(usize::from(required_signers), internal_keys)
-            .map_err(|_| Error::InvalidMultisigDescriptor)?;
-
-    Ok([external_descriptor, internal_descriptor])
+    Ok((external_keys, internal_keys))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{AddressType, MultiSigSigner};
     use bdk_wallet::bitcoin::hashes::{Hash, sha256};
     use bdk_wallet::bitcoin::opcodes::all::{OP_EQUAL, OP_HASH160, OP_PUSHBYTES_0, OP_RETURN};
     use bdk_wallet::bitcoin::{Amount, Script, ScriptBuf, WScriptHash};
@@ -245,6 +318,64 @@ mod tests {
             value: Amount::from_sat(1000),
             script_pubkey: p2sh_script_pubkey(),
         }
+    }
+
+    fn registered_legacy_output(
+        seed_offset: u8,
+        keychain: KeychainKind,
+    ) -> (psbt::Output, TxOut, MultiSigDetails) {
+        let secp = Secp256k1::new();
+        let address_index = 7;
+        let mut signers = Vec::new();
+        let mut derivations = BTreeMap::new();
+
+        for cosigner in 0..2 {
+            let master =
+                Xpriv::new_master(Network::Bitcoin, &[seed_offset + cosigner as u8; 32]).unwrap();
+            let fingerprint = master.fingerprint(&secp);
+            let account_path = DerivationPath::from(vec![
+                ChildNumber::Hardened { index: 45 },
+                ChildNumber::Normal { index: cosigner },
+            ]);
+            let account_xpriv = master.derive_priv(&secp, &account_path).unwrap();
+            signers.push(MultiSigSigner::new(
+                &account_path,
+                &fingerprint,
+                &Xpub::from_priv(&secp, &account_xpriv),
+            ));
+
+            let mut address_path = account_path.as_ref().to_vec();
+            address_path.extend([
+                ChildNumber::Normal {
+                    index: keychain as u32,
+                },
+                ChildNumber::Normal {
+                    index: address_index,
+                },
+            ]);
+            let address_path = DerivationPath::from(address_path);
+            let public_key =
+                Xpub::from_priv(&secp, &master.derive_priv(&secp, &address_path).unwrap())
+                    .public_key;
+            derivations.insert(public_key, (fingerprint, address_path));
+        }
+
+        let multisig = MultiSigDetails::new(2, 2, AddressType::P2sh, None, signers).unwrap();
+        let descriptor = multisig
+            .to_descriptor(keychain, &secp, None)
+            .unwrap()
+            .0
+            .derived_descriptor(&secp, address_index)
+            .unwrap();
+        let redeem_script = descriptor.explicit_script().unwrap();
+        let txout = TxOut {
+            value: Amount::from_sat(1000),
+            script_pubkey: descriptor.script_pubkey(),
+        };
+        let mut output = output_with_scripts(redeem_script, None);
+        output.bip32_derivation = derivations;
+
+        (output, txout, multisig)
     }
 
     /// A nested P2SH-P2WSH with a malformed witness_script must not panic.
@@ -346,10 +477,41 @@ mod tests {
         ));
     }
 
-    /// An unsupported (legacy) P2SH redeem_script must return Unimplemented,
+    #[test]
+    fn registered_legacy_p2sh_change_is_recognized() {
+        let (output, txout, multisig) = registered_legacy_output(1, KeychainKind::Internal);
+        let result = validate_output(
+            &Secp256k1::new(),
+            &output,
+            &txout,
+            Network::Bitcoin,
+            0,
+            Some(&multisig),
+        )
+        .unwrap();
+        assert!(matches!(result.kind, OutputKind::Change(_)));
+    }
+
+    #[test]
+    fn unregistered_legacy_p2sh_output_is_external() {
+        let (output, txout, _) = registered_legacy_output(1, KeychainKind::Internal);
+        let (_, _, different_multisig) = registered_legacy_output(3, KeychainKind::Internal);
+        let result = validate_output(
+            &Secp256k1::new(),
+            &output,
+            &txout,
+            Network::Bitcoin,
+            0,
+            Some(&different_multisig),
+        )
+        .unwrap();
+        assert!(matches!(result.kind, OutputKind::External(_)));
+    }
+
+    /// An unsupported P2SH redeem_script must return a structured error,
     /// not panic.
     #[test]
-    fn legacy_p2sh_returns_unimplemented() {
+    fn non_multisig_p2sh_returns_invalid_redeem_script() {
         // Use a tiny non-segwit redeem script.
         let redeem_script = Script::builder()
             .push_opcode(OP_PUSHBYTES_0)
@@ -365,6 +527,9 @@ mod tests {
             0,
             None,
         );
-        assert!(matches!(result, Err(Error::Unimplemented)));
+        assert!(matches!(
+            result,
+            Err(Error::InvalidRedeemScript { index: 0 })
+        ));
     }
 }


### PR DESCRIPTION
## What changed

Adds focused support for legacy `sh(sortedmulti(...))` multisig accounts:

- imports and serializes legacy P2SH descriptors, including `crypto-output`
- preserves per-cosigner BIP-45 derivation prefixes
- reconstructs legacy account descriptors from PSBT inputs and requires `non_witness_utxo`
- routes registered legacy inputs and outputs through the shared registered-multisig path and script validation
- enforces the 15-key legacy script limit
- adds P2SH-specific regression coverage

## Dependencies

This branch is temporarily stacked on:

- #139, which preserves fixed derivation prefixes during multisig import
- #140, which provides the shared registered-multisig path resolver and output classifier

Once those merge, this branch can be rebased onto `main` without changing its P2SH behavior.

## Scope

The general multisig PSBT hardening was moved to and merged through #134. This PR now contains only the remaining bare-P2SH compatibility layer on top of the shared path handling.
