### PR TITLE
Generalize registered multisig path validation

### DIFF
--- a/src/psbt.rs
+++ b/src/psbt.rs
@@ -1020,14 +1020,13 @@ fn validate_registered_multisig_input<C: Signing + Verification>(
     funding_script_pubkey: &ScriptBuf,
     index: usize,
 ) -> Result<(), Error> {
-    let our_path = bip32_derivations
-        .values()
-        .find(|(fp, _)| *fp == fingerprint)
-        .map(|(_, path)| path)
+    let (keychain, address_index) = bip32_derivations
+        .iter()
+        .filter(|(_, (candidate, _))| *candidate == fingerprint)
+        .find_map(|(public_key, source)| {
+            registered_multisig_signer_path(secp, multisig, public_key, source)
+        })
         .ok_or(Error::FraudulentInput { index })?;
-
-    let (keychain, address_index) =
-        bip48_keychain_and_index(our_path).ok_or(Error::FraudulentInput { index })?;
 
     let matches = registered_script_pubkey(secp, multisig, keychain, address_index)
         .is_some_and(|script| script == *funding_script_pubkey);
@@ -1067,11 +1066,93 @@ fn registered_script_pubkey<C: Signing + Verification>(
         .map(|descriptor| descriptor.script_pubkey())
 }
 
-fn bip48_keychain_and_index(path: &DerivationPath) -> Option<(KeychainKind, u32)> {
-    let account_path = NgAccountPath::parse(path).ok()??;
-    if account_path.purpose != 48 || !account_path.is_for_address() {
+pub(crate) fn registered_multisig_keychain_and_index<C: Verification>(
+    secp: &Secp256k1<C>,
+    multisig: &MultiSigDetails,
+    bip32_derivations: &BTreeMap<PublicKey, KeySource>,
+) -> Option<(KeychainKind, u32)> {
+    if bip32_derivations.len() != multisig.get_signers().len() {
         return None;
     }
-    // The derived script comparison validates the account's script type.
-    Some((account_path.keychain_kind()?, account_path.address_index?))
+
+    let mut resolved = None;
+    for (public_key, source) in bip32_derivations {
+        let path = registered_multisig_signer_path(secp, multisig, public_key, source)?;
+        match resolved {
+            Some(previous) if previous != path => return None,
+            None => resolved = Some(path),
+            _ => {}
+        }
+    }
+
+    resolved
+}
+
+fn registered_multisig_signer_path<C: Verification>(
+    secp: &Secp256k1<C>,
+    multisig: &MultiSigDetails,
+    public_key: &PublicKey,
+    (fingerprint, path): &KeySource,
+) -> Option<(KeychainKind, u32)> {
+    multisig.get_signers().iter().find_map(|signer| {
+        if signer.get_fingerprint() != *fingerprint {
+            return None;
+        }
+
+        let signer_origin = signer.get_derivation().ok()?;
+        let suffix = path.as_ref().strip_prefix(signer_origin.as_ref())?;
+        let [
+            ChildNumber::Normal { index: keychain },
+            ChildNumber::Normal {
+                index: address_index,
+            },
+        ] = suffix
+        else {
+            return None;
+        };
+
+        let derived = signer
+            .get_pubkey()
+            .ok()?
+            .derive_pub(secp, &DerivationPath::from(suffix.to_vec()))
+            .ok()?;
+        if derived.public_key != *public_key {
+            return None;
+        }
+
+        let keychain = match keychain {
+            0 => KeychainKind::External,
+            1 => KeychainKind::Internal,
+            _ => return None,
+        };
+        Some((keychain, *address_index))
+    })
+}
+
+pub(crate) fn registered_multisig_output_kind<C: Signing + Verification>(
+    secp: &Secp256k1<C>,
+    multisig: &MultiSigDetails,
+    bip32_derivations: &BTreeMap<PublicKey, KeySource>,
+    script_pubkey: &ScriptBuf,
+    address: Address,
+) -> Option<OutputKind> {
+    let (keychain, address_index) =
+        registered_multisig_keychain_and_index(secp, multisig, bip32_derivations)?;
+    let registered_script = registered_script_pubkey(secp, multisig, keychain, address_index)?;
+    if registered_script != *script_pubkey {
+        return None;
+    }
+
+    Some(match keychain {
+        KeychainKind::Internal => OutputKind::Change(address),
+        KeychainKind::External => {
+            let account = bip32_derivations
+                .values()
+                .find_map(|(_, path)| NgAccountPath::parse(path).ok().flatten())
+                .filter(|path| path.purpose == 48 && path.is_for_address())
+                .map(|path| path.account)
+                .unwrap_or_default();
+            OutputKind::Transfer { address, account }
+        }
+    })
 }

--- a/src/psbt/p2sh.rs
+++ b/src/psbt/p2sh.rs
@@ -1,8 +1,8 @@
 use crate::bip32::NgAccountPath;
 use crate::config::MultiSigDetails;
 use crate::psbt::{
-    Error, OutputKind, PsbtOutput, bip48_keychain_and_index, derive_account_xpub,
-    derive_full_descriptor_pubkey, registered_script_pubkey, sort_keys,
+    Error, OutputKind, PsbtOutput, derive_account_xpub, derive_full_descriptor_pubkey,
+    registered_multisig_output_kind, sort_keys,
 };
 use bdk_wallet::bitcoin::bip32::{ChildNumber, DerivationPath, KeySource, Xpriv, Xpub};
 use bdk_wallet::bitcoin::psbt;
@@ -60,22 +60,17 @@ pub fn validate_output<C: Signing + Verification>(
             return Err(Error::FraudulentOutput { index });
         }
 
-        let path = registered_multisig.and_then(|multisig| {
-            let mut paths = output.bip32_derivation.values();
-            let (_, path) = paths.next()?;
-            if !paths.all(|(_, other_path)| other_path == path) {
-                return None;
-            }
-
-            let (keychain, address_index) = bip48_keychain_and_index(path)?;
-            let script = registered_script_pubkey(secp, multisig, keychain, address_index)?;
-            (script == txout.script_pubkey).then_some(path)
-        });
-
-        let kind = match path {
-            Some(path) => OutputKind::from_derivation_path(path, 48, network, address)?,
-            None => OutputKind::External(address),
-        };
+        let kind = registered_multisig
+            .and_then(|multisig| {
+                registered_multisig_output_kind(
+                    secp,
+                    multisig,
+                    &output.bip32_derivation,
+                    &txout.script_pubkey,
+                    address.clone(),
+                )
+            })
+            .unwrap_or(OutputKind::External(address));
 
         Ok(PsbtOutput {
             amount: txout.value,

--- a/src/psbt/p2wsh.rs
+++ b/src/psbt/p2wsh.rs
@@ -1,7 +1,5 @@
 use crate::config::MultiSigDetails;
-use crate::psbt::{
-    Error, OutputKind, PsbtOutput, bip48_keychain_and_index, registered_script_pubkey, sort_keys,
-};
+use crate::psbt::{Error, OutputKind, PsbtOutput, registered_multisig_output_kind, sort_keys};
 use bdk_wallet::bitcoin::bip32::{ChildNumber, DerivationPath, KeySource, Xpub};
 use bdk_wallet::bitcoin::psbt;
 use bdk_wallet::bitcoin::secp256k1::{PublicKey, Secp256k1, Signing, Verification};
@@ -45,22 +43,17 @@ pub fn validate_output<C: Signing + Verification>(
         return Err(Error::FraudulentOutput { index });
     }
 
-    let path = registered_multisig.and_then(|multisig| {
-        let mut paths = output.bip32_derivation.values();
-        let (_, path) = paths.next()?;
-        if !paths.all(|(_, other_path)| other_path == path) {
-            return None;
-        }
-
-        let (keychain, address_index) = bip48_keychain_and_index(path)?;
-        let script = registered_script_pubkey(secp, multisig, keychain, address_index)?;
-        (script == txout.script_pubkey).then_some(path)
-    });
-
-    let kind = match path {
-        Some(path) => OutputKind::from_derivation_path(path, 48, network, address)?,
-        None => OutputKind::External(address),
-    };
+    let kind = registered_multisig
+        .and_then(|multisig| {
+            registered_multisig_output_kind(
+                secp,
+                multisig,
+                &output.bip32_derivation,
+                &txout.script_pubkey,
+                address.clone(),
+            )
+        })
+        .unwrap_or(OutputKind::External(address));
 
     Ok(PsbtOutput {
         amount: txout.value,

--- a/tests/psbt_multisig_security.rs
+++ b/tests/psbt_multisig_security.rs
@@ -45,14 +45,26 @@ fn keys_at(
     suffix: &str,
     masters: &[Xpriv],
 ) -> Vec<(SecpPublicKey, Fingerprint, DerivationPath)> {
-    let path = DerivationPath::from_str(&format!("{account}/{suffix}")).unwrap();
-    masters
+    let accounts = vec![account.clone(); masters.len()];
+    keys_at_roots(secp, &accounts, suffix, masters)
+}
+
+fn keys_at_roots(
+    secp: &Secp256k1<All>,
+    accounts: &[DerivationPath],
+    suffix: &str,
+    masters: &[Xpriv],
+) -> Vec<(SecpPublicKey, Fingerprint, DerivationPath)> {
+    assert_eq!(accounts.len(), masters.len());
+    accounts
         .iter()
-        .map(|m| {
+        .zip(masters)
+        .map(|(account, master)| {
+            let path = DerivationPath::from_str(&format!("{account}/{suffix}")).unwrap();
             (
-                xpub_at(secp, m, &path).public_key,
-                m.fingerprint(secp),
-                path.clone(),
+                xpub_at(secp, master, &path).public_key,
+                master.fingerprint(secp),
+                path,
             )
         })
         .collect()
@@ -141,11 +153,19 @@ fn output_for(format: AddressType, script: &ScriptBuf, keys: &Keys) -> (TxOut, p
 /// An honest spend from the registered 2-of-2 wallet (device = seed 1,
 /// cosigner = seed 2): input at `/0/0`, change at `/1/0`, external payment.
 fn honest_psbt(format: AddressType) -> (Psbt, MultiSigDetails) {
-    let secp = Secp256k1::new();
     let acct = account_path(format, 0);
+    honest_psbt_with_roots(format, [acct.clone(), acct])
+}
 
-    let input_keys = keys_at(&secp, &acct, "0/0", &[master(1), master(2)]);
-    let change_keys = keys_at(&secp, &acct, "1/0", &[master(1), master(2)]);
+fn honest_psbt_with_roots(
+    format: AddressType,
+    accounts: [DerivationPath; 2],
+) -> (Psbt, MultiSigDetails) {
+    let secp = Secp256k1::new();
+    let masters = [master(1), master(2)];
+
+    let input_keys = keys_at_roots(&secp, &accounts, "0/0", &masters);
+    let change_keys = keys_at_roots(&secp, &accounts, "1/0", &masters);
     let input_script = multi_script(2, [input_keys[0].0, input_keys[1].0]);
     let (change_txout, change_output) = output_for(
         format,
@@ -153,7 +173,7 @@ fn honest_psbt(format: AddressType) -> (Psbt, MultiSigDetails) {
         &change_keys,
     );
 
-    let payment = keys_at(&secp, &acct, "0/0", &[master(3)]);
+    let payment = keys_at(&secp, &account_path(format, 0), "0/0", &[master(3)]);
     let tx = Transaction {
         version: Version::TWO,
         lock_time: LockTime::ZERO,
@@ -170,20 +190,77 @@ fn honest_psbt(format: AddressType) -> (Psbt, MultiSigDetails) {
     let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
     psbt.inputs = vec![input_for(format, &input_script, INPUT_SATS, &input_keys)];
     psbt.outputs = vec![change_output, psbt::Output::default()];
-    for m in [master(1), master(2)] {
+    for (master, account) in masters.iter().zip(&accounts) {
         psbt.xpub.insert(
-            xpub_at(&secp, &m, &acct),
-            (m.fingerprint(&secp), acct.clone()),
+            xpub_at(&secp, master, account),
+            (master.fingerprint(&secp), account.clone()),
         );
     }
 
-    let signers = [master(1), master(2)]
+    let signers = masters
         .iter()
-        .map(|m| MultiSigSigner::new(&acct, &m.fingerprint(&secp), &xpub_at(&secp, m, &acct)))
+        .zip(&accounts)
+        .map(|(master, account)| {
+            MultiSigSigner::new(
+                account,
+                &master.fingerprint(&secp),
+                &xpub_at(&secp, master, account),
+            )
+        })
         .collect();
     let details =
         MultiSigDetails::new(2, 2, format, Some(NetworkKind::Test.into()), signers).unwrap();
     (psbt, details)
+}
+
+#[test]
+fn registered_vendor_paths_validate_against_saved_signer_roots() {
+    let cases = [
+        (
+            AddressType::P2ShWsh,
+            [
+                DerivationPath::from_str("m/49/1/0").unwrap(),
+                DerivationPath::from_str("m/49/1/0").unwrap(),
+            ],
+        ),
+        (
+            AddressType::P2ShWsh,
+            [
+                DerivationPath::from_str("m/45'/1/0").unwrap(),
+                DerivationPath::from_str("m/45'/1/0").unwrap(),
+            ],
+        ),
+        (
+            AddressType::P2wsh,
+            [
+                DerivationPath::from_str("m/45'/1'/11'/2").unwrap(),
+                DerivationPath::from_str("m/45'/1'/12'/2").unwrap(),
+            ],
+        ),
+    ];
+
+    for (format, accounts) in cases {
+        let (mut psbt, details) = honest_psbt_with_roots(format, accounts.clone());
+        let result = validate_with(&details, &psbt).expect("registered spend must validate");
+        assert!(
+            matches!(result.outputs[0].kind, OutputKind::Change(_)),
+            "format {format:?}"
+        );
+        assert_eq!(result.display_total(), Amount::from_sat(PAYMENT_SATS));
+
+        let receive_keys =
+            keys_at_roots(&Secp256k1::new(), &accounts, "0/7", &[master(1), master(2)]);
+        let receive_script = multi_script(2, [receive_keys[0].0, receive_keys[1].0]);
+        let (receive_txout, receive_output) = output_for(format, &receive_script, &receive_keys);
+        psbt.unsigned_tx.output[0] = receive_txout;
+        psbt.outputs[0] = receive_output;
+
+        let result = validate_with(&details, &psbt).expect("registered transfer must validate");
+        assert!(
+            matches!(result.outputs[0].kind, OutputKind::Transfer { .. }),
+            "format {format:?}"
+        );
+    }
 }
 
 fn validate_with(details: &MultiSigDetails, psbt: &Psbt) -> Result<TransactionDetails, Error> {


### PR DESCRIPTION
## Summary

- resolve registered multisig receive/change paths relative to each saved signer origin
- verify each derived public key against its registered signer xpub before classifying inputs or outputs
- reuse one registered-output classifier for P2WSH and P2SH-P2WSH

## Why

Registered multisig validation assumed every signer used the same BIP48 path. Coordinators can legitimately use different signer roots or non-BIP48 roots while still producing an already-supported P2WSH or P2SH-P2WSH descriptor. Those transactions could be rejected before the registered BDK wallet was allowed to sign them.

The saved `MultiSigDetails` is now the authority: each PSBT derivation must be a receive/change child of its corresponding saved signer, all signers must resolve to the same branch and address index, and the reconstructed registered script must match the transaction.

## Scope

This does not add legacy P2SH support or broaden the accepted descriptor formats.
